### PR TITLE
Change back to CAN specific interrupt disables.

### DIFF
--- a/examples/Write/Write.ino
+++ b/examples/Write/Write.ino
@@ -53,7 +53,6 @@ void loop() {
     Can.write(CAN_TX_msg);
 
     CAN_TX_msg.id = (0xA63);
-    CAN_TX_msg.flags.extended = 0;  // Back to standard ID.
     CAN_TX_msg.len = 8;
     CAN_TX_msg.buf[0] =  0x63;
     CAN_TX_msg.buf[1] =  0x49;
@@ -67,6 +66,7 @@ void loop() {
     Can.write(CAN_TX_msg);
 
     CAN_TX_msg.id = (0x23);
+    CAN_TX_msg.flags.extended = 0;  // Back to standard ID.
     CAN_TX_msg.len = 8;
     CAN_TX_msg.buf[0] =  0x03;
     CAN_TX_msg.buf[1] =  0x41;


### PR DESCRIPTION
Disabling all the interrupts because of the CAN messages isn't good idea at all. This seems to cause lot of issues on my indented use of this library. So back to original implementation in that regards.