### PR TITLE
Update actions for multiple targets

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -1,12 +1,22 @@
-name: Compile Examples
+name: Compile Examples for STM32
 
 on:
   - push
   - pull_request
 
 jobs:
-  compile-examples-stm32:
+  compile:
     runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: false
+    
+      matrix:
+        board:
+          - fqbn: "Nucleo_144"
+          - fqbn: "GenF1:pnum=GENERIC_F103C8TX"
+          - fqbn: "GenF4:pnum=GENERIC_F412RETX"
+          - fqbn: "GenF4:pnum=GENERIC_F407VETX"
     
     steps:
       - name: Checkout repository
@@ -15,8 +25,8 @@ jobs:
         uses: arduino/compile-sketches@main
         with:
           platforms: |
-            - name: "STM32:stm32"
-              source-url: https://raw.githubusercontent.com/stm32duino/BoardManagerFiles/master/STM32/package_stm_index.json
-          fqbn: "STM32:stm32:Nucleo_144"
+            - name: "STMicroelectronics:stm32"
+              source-url: https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json
+          fqbn: STMicroelectronics:stm32:${{ matrix.board.fqbn }}
           libraries: |
             - source-path: ./ 

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -14,5 +14,5 @@ jobs:
       - name: Lint check
         uses: arduino/arduino-lint-action@v1
         with:
-          library-manager: submit
+          library-manager: update
           compliance: strict


### PR DESCRIPTION
Hello,
this is the way to compile the examples for many targets, its using the matrix function.

It compiles for the 4 targets that where seen here: https://github.com/pazi88/STM32_CAN/commit/04553a92a9cb367c070cb0e2d22c477f13acb97b

see here for a run with this changes: https://github.com/designer2k2/STM32_CAN/actions/runs/5136521761

If you want to add more targets just add it into the matrix list.

Further i updated:
- use latest manager link (its now STMicroelectronics and not STM32) https://github.com/stm32duino/Arduino_Core_STM32
- use matrix for multiple target
- change lint to update as lib is now in manager