### PR TITLE
Revise baudrate calculations

### DIFF
--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -545,8 +545,16 @@ void STM32_CAN::setBaudRateValues(CAN_HandleTypeDef *CanHandle, uint16_t prescal
   uint32_t _TimeSeg1 = 0;
   uint32_t _TimeSeg2 = 0;
   uint32_t _Prescaler = 0;
+
+  /* the CAN specification (v2.0) states that SJW shall be programmable between
+   * 1 and min(4, timeseg1)... the bxCAN documentation doesn't mention this
+   */
+  if (sjw > 4) sjw = 4;
+  if (sjw > timeseg1) sjw = timeseg1;
+
   switch (sjw)
   {
+    case 0:
     case 1:
       _SyncJumpWidth = CAN_SJW_1TQ;
       break;
@@ -557,11 +565,8 @@ void STM32_CAN::setBaudRateValues(CAN_HandleTypeDef *CanHandle, uint16_t prescal
       _SyncJumpWidth = CAN_SJW_3TQ;
       break;
     case 4:
+    default: /* limit to 4 */
       _SyncJumpWidth = CAN_SJW_4TQ;
-      break;
-    default:
-      // should not happen
-      _SyncJumpWidth = CAN_SJW_1TQ;
       break;
   }
 
@@ -685,7 +690,7 @@ void STM32_CAN::calculateBaudrate(CAN_HandleTypeDef *CanHandle, int baud)
       setBaudRateValues(CanHandle, BAUD_RATE_TABLE_48M[i].prescaler,
                                    BAUD_RATE_TABLE_48M[i].timeseg1,
                                    BAUD_RATE_TABLE_48M[i].timeseg2,
-                                   1);
+                                   4);
       return;
     }
   }
@@ -699,7 +704,7 @@ void STM32_CAN::calculateBaudrate(CAN_HandleTypeDef *CanHandle, int baud)
       setBaudRateValues(CanHandle, BAUD_RATE_TABLE_45M[i].prescaler,
                                    BAUD_RATE_TABLE_45M[i].timeseg1,
                                    BAUD_RATE_TABLE_45M[i].timeseg2,
-                                   1);
+                                   4);
       return;
     }
   }

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -188,6 +188,9 @@ class STM32_CAN {
     void      initializeBuffers(void);
     bool      isRingBufferEmpty(RingbufferTypeDef &ring);
     uint32_t  ringBufferCount(RingbufferTypeDef &ring);
+
+    template <typename T, size_t N>
+    bool      lookupBaudrate(CAN_HandleTypeDef *CanHandle, int Baudrate, const T(&table)[N]);
     void      calculateBaudrate(CAN_HandleTypeDef *CanHandle, int Baudrate);
     void      setBaudRateValues(CAN_HandleTypeDef *CanHandle, uint16_t prescaler, uint8_t timeseg1,
                                                               uint8_t timeseg2, uint8_t sjw);


### PR DESCRIPTION
As discussed in #40, the baudrate calculations should not consider SJW as part of the bit time.

This PR revises the timing calculations to exclude SJW, performance is also improved while maintaining a sample point between 75-95%.

Out-of-bounds SJW values are clamped, and the value is kept as high as possible for improved interoperability.
The lookup of pre-calculated timing configuration is also improved.

---

During calculation, all prescaler values that are _unable_ to achieve the desired baudrate are immediately skipped, and restricting BS1/BS2 values as below allows us to also discard a large number of iterations that would produce inferior configurations.

Compared to the previous code, we gain 15x potential configuration options per prescaler value, and also discard 3x inferior options (early sample point)... this is 45x total vs 33x previously.

The number of time quanta for each BS1 / BS2 value is shown below:
![image](https://github.com/user-attachments/assets/77f54bf4-5e16-4f4e-9252-d31e09b30ffa)

This translates into a sample point as shown in this table - all values <75% are ignored (previous options ringed in blue).
![image](https://github.com/user-attachments/assets/f355dbf3-5a3c-43c2-a572-add2708cda6e)

This means that we can limit `BS2` to values between 1 and 5, and `BS1` may then start from `(BS2 * 3) - 1`.
![image](https://github.com/user-attachments/assets/bbfd14eb-d571-4fd1-b1da-4ac172738619)