### PR TITLE
Lots of improvements, FDCAN preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,27 @@ STM32 core: https://github.com/stm32duino/Arduino_Core_STM32
 
 ## How to use.
 To use this library, CAN module needs to be enabled in HAL drivers. If PIO is used, it's enough
-to add -DHAL_CAN_MODULE_ENABLED as build flag. With Arduino IDE it's easiest to create hal_conf_extra.h -file
-to same folder with sketch and haven #define HAL_CAN_MODULE_ENABLED there. See examples for this.
+to add `-DHAL_CAN_MODULE_ENABLED` as build flag. With Arduino IDE it's easiest to create `hal_conf_extra.h` file
+to same folder with sketch and haven `#define HAL_CAN_MODULE_ENABLED` there. See examples for this.
 
 ### Setup
 The sketch needs include in the header to use the library.
-```
+```Cpp
 #include "STM32_CAN.h"
 ```
 Use constructor to set which CAN interface and pins to use.
+```Cpp
+STM32_CAN Can1( CAN1 ); //by peripheral. Uses first pin defined in arduino PeripheralPins maps
+STM32_CAN Can1( PA11 /* rx pin */, PA12 /* tx pin */); //by arduino digital pin number. Finds matching peripheral automatically
+STM32_CAN Can1( PA_11, PA_12 ); //by PinName. Finds matching peripheral automatically
 ```
+**Note**: Digital pin and PinName may not be mixed or one will be implicitly converted and possibly causing unintended behavior. PinNames are defined with an underscore between port and pin. Digital pin numbers are aliased with port and pinnumber without an underscore.
+Can convert between the two with `digitalPinToPinName()` and `pinNametoDigitalPin()`.
+
+Tx pin may be defined as `PNUM_NOT_DEFINED` (digital pin number) or `NC` (PinName). Then only Rx is setup, allowing a listen only mode.
+
+The original method by choosing from 3 sets of fixed pin combinations can still be used as well for compatibility.
+```Cpp
 STM32_CAN Can1( CAN1, DEF );
 ```
 Depending on the STM32 model, there is CAN1, CAN2 and CAN3 available.
@@ -45,11 +56,98 @@ The pins are:
    - ALT: PB3/4
 
 In constructor you can optionally set TX and RX buffer sizes. Default is 16 messages.
+```Cpp
+STM32_CAN Can1 (PA_11, PA_12, RX_SIZE_256, TX_SIZE_256);
 ```
-STM32_CAN Can1 (CAN1, ALT_2, RX_SIZE_256, TX_SIZE_256);
+
+#### Additional settings
+Following settings may be changed before starting the driver with `begin()`.
+```Cpp
+setIRQPriority(uint32_t preemptPriority, uint32_t subPriority); // default: lowest prio, 0
+setAutoRetransmission(bool enabled);  //default: true
+setRxFIFOLock(bool fifo0locked);      //default: false
+setTxBufferMode(TX_BUFFER_MODE mode); //default: FIFO
+setTimestampCounter(bool enabled);    //default: false
+setMode(MODE mode);                   //default: NORMAL
+setAutoBusOffRecovery(bool enabled);  //default: false
 ```
-There is structure to contain CAN packets and info about those.
+**Note**: `setTimestampCounter()` should always be set `false`. Feature is marked as non functioning in Erratas.
+
+**Note**: begin() will overwrite `setAutoRetransmission()` setting (`false` by default).
+
+#### Start / Stop bus
+
+Before using library commands, begin must be called.
+```Cpp
+Can1.begin();
 ```
+Optionally automatic retransmission can be enabled with begin.
+```Cpp
+Can1.begin(true);
+```
+Set baud rate by using.
+```Cpp
+Can1.setBaudRate(500000);
+```
+500 kbit/s in this case.
+
+`setBaudRate` may be called before or after begin. Bus start once both are called.
+
+It may also be called while running to change baudrate.
+
+Call
+```Cpp
+Can1.end();
+```
+to stop the bus and release all resources. Will be implicitly called by destructor when freeing object.
+Only one STM32_CAN instance can control a CAN Peripheral at one time. It reserves the peripheral from begin() to end().
+
+#### Filters
+Filters may only be set after bus is started (`begin()` & `setBaudRate()` was called).
+
+By default bank 0 will receive CAN messages with all IDs. But using filters, we can set the CAN to receive
+only specific message IDs. The CAN peripheral has many different methods of defining filters for messages.
+These functions help setting up filters:
+```Cpp
+bool setFilterSingleMask(uint8_t bank_num, uint32_t id,  uint32_t mask,  IDE std_ext);
+bool setFilterDualID    (uint8_t bank_num, uint32_t id1, uint32_t id2,   IDE std_ext1, IDE std_ext2);
+bool setFilterDualMask  (uint8_t bank_num, uint32_t id1, uint32_t mask1, IDE std_ext1, uint32_t id2, uint32_t mask2, IDE std_ext2);
+bool setFilterQuadID    (uint8_t bank_num, uint32_t id1, IDE std_ext1, uint32_t id2, IDE std_ext2, uint32_t id3, IDE std_ext3, uint32_t id4, IDE std_ext4);
+```
+The simplest one is `setFilterSingleMask`. The others allow setting multiple filters into a single filter bank. When using the functions `setFilterDualMask` and `setFilterQuadID` for extended ids, the 15 LSBs of the ID are always masked out.
+
+Example: we want to receive only messages with standard ID 0x153 and extended ID 0x613, so we use bank 0 and 1.
+```Cpp
+Can1.setFilterSingleMask( 0, 0x153, 0x7FF, STD);
+Can1.setFilterSingleMask( 1, 0x613, 0x1FFFFFFF, EXT);
+```
+First number is the bank number. Second is message ID. 3rd ID mask. And last one defines ID type: `AUTO`, `STD` or `EXT`.
+
+
+**Note**: optional args of filter settings allow storing messages into the non-default RxFIFO. `read()` currently only reads from the default FIFO, so messages will not be accessible if sent to other FIFO.
+
+**Note**: the following function allowed setting filters in the past. This function was bugged and did only work as long as optional args filter_mode and filter_scale where not changed.
+Its behavior was kept in the broken state for compatibility. It has a 4th arg for ID type, defaults to `AUTO`.
+```Cpp
+bool setFilter(uint8_t bank_num, uint32_t filter_id, uint32_t mask)
+```
+
+To disable a filter bank call (`true` to re-enable it)
+```Cpp
+Can1.setFilter(bank_num, false);
+```
+
+
+The amount of available filter banks can be queried with:
+```Cpp
+Can1.getFilterBankCount()
+```
+**Note**: Single CAN devices have 14, dual CAN devices 28. Driver does split the 28 into 14 for each CAN instance.
+
+
+### Main loop
+The library defines this structure to describe a CAN message.
+```Cpp
 typedef struct CAN_message_t {
   uint32_t id = 0;         // can identifier
   uint16_t timestamp = 0;  // time when message arrived
@@ -67,41 +165,20 @@ typedef struct CAN_message_t {
   bool seq = 0;            // sequential frames
 } CAN_message_t;
 ```
-In sketch.
-```
-static CAN_message_t CAN_msg;
-```
-Before using library commands, begin must be called.
-```
-Can1.begin();
-```
-Optionally automatic retransmission can be enabled with begin.
-```
-Can1.begin(true);
-```
-Set baud rate by using.
-```
-Can1.setBaudRate(500000);
-```
-500 kbit/s in this case.
 
-By default bank 0 will receive CAN messages with all IDs. But using filters, we can set the CAN to receive
-only specific message IDs. Ie. if we want to receive only message IDs 0x153 and 0x613, so we use bank 0 and 1.
+Define variable to store a message
+```Cpp
+CAN_message_t CAN_msg;
 ```
-Can1.setFilter( 0, 0x153, 0x1FFFFFFF );
-Can1.setFilter( 1, 0x613, 0x1FFFFFFF );
-```
-First number is the bank number. Second is message ID. And last one is mask.
 
-### Main loop
 To read CAN messages from buffer:
-```
-Can1.read(CAN_msg)
+```Cpp
+Can1.read(CAN_msg);
 ```
 This will return true if there is messages available on receive buffer.
 
 To write messages to send queue.
-```
+```Cpp
 Can1.write(CAN_msg);
 ```
 This will return true if there room in the send queue.

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -2,7 +2,7 @@
 
 #include "core_debug.h"
 
-#ifdef HAL_CEC_MODULE_ENABLED && defined(STM32_CAN1_SHARED_WITH_CEC)
+#if defined(HAL_CEC_MODULE_ENABLED) && defined(STM32_CAN1_SHARED_WITH_CEC)
 /** Pointer to CEC_HandleTypeDef structure that contains 
  * the configuration information for the specified CEC.
  * Application have to declare them properly to be able to call
@@ -1174,7 +1174,7 @@ void STM32_CAN::disableMBInterrupts()
   if (_can.handle.Instance == CAN1)
   {
     #ifdef CAN1_IRQn_AIO
-    #ifdef HAL_CEC_MODULE_ENABLED && defined(STM32_CAN1_SHARED_WITH_CEC)
+    #if defined(HAL_CEC_MODULE_ENABLED) && defined(STM32_CAN1_SHARED_WITH_CEC)
     //only disable if cec instance is not set/used
     if(!phcec)
     #endif
@@ -1305,7 +1305,7 @@ extern "C" void CAN1_IRQHandler_AIO(void)
   if(canObj[CAN1_INDEX]) {
     HAL_CAN_IRQHandler(&canObj[CAN1_INDEX]->handle);
   }
-  #ifdef HAL_CEC_MODULE_ENABLED && defined(STM32_CAN1_SHARED_WITH_CEC)
+  #if defined(HAL_CEC_MODULE_ENABLED) && defined(STM32_CAN1_SHARED_WITH_CEC)
   if(phcec)
   {
     HAL_CEC_IRQHandler(phcec);

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -1006,7 +1006,7 @@ bool STM32_CAN::calculateBaudrate(CAN_HandleTypeDef *CanHandle, int baud)
   uint8_t bs2;
   uint16_t prescaler;
 
-  const uint32_t frequency = getAPB1Clock();
+  const uint32_t frequency = getCanPeripheralClock();
 
   if (frequency == 48000000) {
     if (lookupBaudrate(CanHandle, baud, BAUD_RATE_TABLE_48M)) return true;
@@ -1049,9 +1049,9 @@ bool STM32_CAN::calculateBaudrate(CAN_HandleTypeDef *CanHandle, int baud)
   return false;
 }
 
-uint32_t STM32_CAN::getAPB1Clock()
+uint32_t STM32_CAN::getCanPeripheralClock()
 {
-  //APB1 is PCLK1
+  //All bxCAN get clocked by APB1 / PCLK1
   return HAL_RCC_GetPCLK1Freq();
 }
 

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -218,6 +218,24 @@ CAN_TypeDef * STM32_CAN::getPeripheral()
     return NP;
   }
 
+  #ifdef STM32F1xx
+  /** AF remapping on the F1 platform only possible in pairs
+   *  Verify that both pins use the same remapping
+   *  Only enforced if both pins are used, in Rx only Tx pin is not set to AF*/
+  if(canPort_rx != NP && canPort_tx != NP)
+  {
+    uint32_t rx_func = pinmap_function(rx, PinMap_CAN_RD);
+    uint32_t tx_func = pinmap_function(tx, PinMap_CAN_TD);
+    uint32_t rx_afnum = STM_PIN_AFNUM(rx_func);
+    uint32_t tx_afnum = STM_PIN_AFNUM(tx_func);
+    if(rx_afnum != tx_afnum)
+    {
+      //ERROR
+      return NP;
+    }
+  }
+  #endif
+
   //clear tx pin in case it was set but does not match a peripheral
   if(canPort_tx == NP)
     tx = NC;

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -185,6 +185,7 @@ void STM32_CAN::init(void)
   _can.__this = (void*)this;
   _can.handle.Instance = nullptr;
   baudrate = 0UL;
+  filtersInitialized = false;
 }
 
 CAN_TypeDef * STM32_CAN::getPeripheral()
@@ -313,6 +314,8 @@ void STM32_CAN::begin( bool retransmission ) {
   _can.handle.Init.ReceiveFifoLocked  = DISABLE;
   _can.handle.Init.TransmitFifoPriority = ENABLE;
   _can.handle.Init.Mode = mode;
+  
+  filtersInitialized = false;
 
   //try to start in case baudrate was set earlier
   setBaudRate(baudrate);
@@ -544,6 +547,8 @@ void STM32_CAN::initializeFilters()
 {
   CAN_FilterTypeDef sFilterConfig;
   if(!_can.handle.Instance) return;
+  if(filtersInitialized) return;
+  filtersInitialized = true;
 
   // We set first bank to accept all RX messages
   sFilterConfig.FilterBank = 0;

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -294,15 +294,13 @@ void STM32_CAN::setBaudRate(uint32_t baud)
   // Start the CAN peripheral
   HAL_CAN_Start( &_can.handle );
 
-  // Activate CAN RX notification
+  // Activate CAN notifications
   #if defined(STM32_CAN1_TX_RX0_BLOCKED_BY_USB) && defined(STM32_CAN_USB_WORKAROUND_POLLING)
   HAL_CAN_ActivateNotification( &_can.handle, CAN_IT_RX_FIFO1_MSG_PENDING);
   #else
   HAL_CAN_ActivateNotification( &_can.handle, CAN_IT_RX_FIFO0_MSG_PENDING);
-  #endif
-
-  // Activate CAN TX notification
   HAL_CAN_ActivateNotification( &_can.handle, CAN_IT_TX_MAILBOX_EMPTY);
+  #endif
 }
 
 bool STM32_CAN::write(CAN_message_t &CAN_tx_msg, bool sendMB)
@@ -312,7 +310,9 @@ bool STM32_CAN::write(CAN_message_t &CAN_tx_msg, bool sendMB)
   CAN_TxHeaderTypeDef TxHeader;
   if(!_can.handle.Instance) return false;
 
+  #if !defined(STM32_CAN1_TX_RX0_BLOCKED_BY_USB)
   __HAL_CAN_DISABLE_IT(&_can.handle, CAN_IT_TX_MAILBOX_EMPTY);
+  #endif
 
   if (CAN_tx_msg.flags.extended == 1) // Extended ID when CAN_tx_msg.flags.extended is 1
   {
@@ -350,7 +350,10 @@ bool STM32_CAN::write(CAN_message_t &CAN_tx_msg, bool sendMB)
     }
     else { ret = false; }
   }
+
+  #if !defined(STM32_CAN1_TX_RX0_BLOCKED_BY_USB)
   __HAL_CAN_ENABLE_IT(&_can.handle, CAN_IT_TX_MAILBOX_EMPTY);
+  #endif
   return ret;
 }
 

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -204,6 +204,11 @@ STM32_CAN::STM32_CAN( CAN_TypeDef* canPort, CAN_PINS pins, RXQUEUE_TABLE rxSize,
   init();
 }
 
+STM32_CAN::~STM32_CAN()
+{
+  end();
+}
+
 void STM32_CAN::init(void)
 {
   _can.__this = (void*)this;

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -676,6 +676,28 @@ void STM32_CAN::initializeFilters()
   #endif
 
   HAL_CAN_ConfigFilter(&_can.handle, &sFilterConfig);
+
+  /** turn off all other filters that might sill be setup from before */
+  sFilterConfig.FilterActivation = DISABLE;
+  uint8_t filter_count = STM32_CAN_SINGLE_CAN_FILTER_COUNT;
+  uint8_t filter_start = 1;
+  #ifdef CAN2
+  /** In dual CAN devices filter banks are shared and setup to equal amounts */
+  if (_can.handle.Instance == CAN1)
+  { 
+    filter_count = STM32_CAN_CAN2_FILTER_OFFSET;
+  }
+  else if (_can.handle.Instance == CAN2)
+  {
+    filter_start += STM32_CAN_CAN2_FILTER_OFFSET;
+    filter_count = STM32_CAN_DUAL_CAN_FILTER_COUNT;
+  }
+  #endif
+  for (uint8_t bank_num = filter_start ; bank_num < filter_count ; bank_num++)
+  {
+    sFilterConfig.FilterBank = bank_num;
+    HAL_CAN_ConfigFilter(&_can.handle, &sFilterConfig);
+  }
 }
 
 void STM32_CAN::initializeBuffers()

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -825,8 +825,12 @@ void STM32_CAN::enableMBInterrupts()
     #ifdef CAN1_IRQn_AIO
     HAL_NVIC_EnableIRQ(CAN1_IRQn_AIO);
     #else
+    #if defined(STM32_CAN1_TX_RX0_BLOCKED_BY_USB) && defined(STM32_CAN_USB_WORKAROUND_POLLING)
+    HAL_NVIC_EnableIRQ(CAN1_RX1_IRQn);
+    #else
     HAL_NVIC_EnableIRQ(CAN1_TX_IRQn);
     HAL_NVIC_EnableIRQ(CAN1_RX0_IRQn);
+    #endif
     #endif /** else defined(CAN1_IRQn_AIO) */
   }
 #ifdef CAN2
@@ -858,8 +862,12 @@ void STM32_CAN::disableMBInterrupts()
       HAL_NVIC_DisableIRQ(CAN1_IRQn_AIO);
     }
     #else
+    #if defined(STM32_CAN1_TX_RX0_BLOCKED_BY_USB) && defined(STM32_CAN_USB_WORKAROUND_POLLING)
+    HAL_NVIC_DisableIRQ(CAN1_RX1_IRQn);
+    #else
     HAL_NVIC_DisableIRQ(CAN1_TX_IRQn);
     HAL_NVIC_DisableIRQ(CAN1_RX0_IRQn);
+    #endif
     #endif /** else defined(CAN1_IRQn_AIO) */
   }
 #ifdef CAN2

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -29,6 +29,15 @@ static STM32_CAN* _CAN3 = nullptr;
 static CAN_HandleTypeDef     hcan3;
 #endif
 
+STM32_CAN::STM32_CAN(uint32_t rx, uint32_t tx, RXQUEUE_TABLE rxSize, TXQUEUE_TABLE txSize)
+  : sizeRxBuffer(rxSize), sizeTxBuffer(txSize),
+    mode(Mode::NORMAL), preemptPriority(MAX_IRQ_PRIO_VALUE), subPriority(0)
+{
+  this->rx = digitalPinToPinName(rx);
+  this->tx = digitalPinToPinName(tx);
+  init();
+}
+
 STM32_CAN::STM32_CAN(PinName rx, PinName tx, RXQUEUE_TABLE rxSize, TXQUEUE_TABLE txSize)
   : rx(rx), tx(tx), sizeRxBuffer(rxSize), sizeTxBuffer(txSize),
     mode(Mode::NORMAL), preemptPriority(MAX_IRQ_PRIO_VALUE), subPriority(0)

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -734,8 +734,15 @@ bool STM32_CAN::setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint3
   if(_can.handle.Instance == CAN2)
   {
     sFilterConfig.FilterBank += STM32_CAN_CAN2_FILTER_OFFSET;
+    if(sFilterConfig.FilterBank >= STM32_CAN_DUAL_CAN_FILTER_COUNT)
+      return false;
   }
+  else
   #endif
+  if(sFilterConfig.FilterBank >= STM32_CAN_SINGLE_CAN_FILTER_COUNT)
+  {
+    return false;
+  }
   // Enable filter
   return (HAL_CAN_ConfigFilter( &_can.handle, &sFilterConfig ) == HAL_OK);
 }

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -730,18 +730,21 @@ void STM32_CAN::enableMBInterrupts()
     HAL_NVIC_EnableIRQ(CAN1_IRQn_AIO);
     #else
     HAL_NVIC_EnableIRQ(CAN1_TX_IRQn);
+    HAL_NVIC_EnableIRQ(CAN1_RX0_IRQn);
     #endif /** else defined(CAN1_IRQn_AIO) */
   }
 #ifdef CAN2
   else if (n_pCanHandle->Instance == CAN2)
   {
     HAL_NVIC_EnableIRQ(CAN2_TX_IRQn);
+    HAL_NVIC_EnableIRQ(CAN2_RX0_IRQn);
   }
 #endif
 #ifdef CAN3
   else if (n_pCanHandle->Instance == CAN3)
   {
     HAL_NVIC_EnableIRQ(CAN3_TX_IRQn);
+    HAL_NVIC_EnableIRQ(CAN3_RX0_IRQn);
   }
 #endif
 }
@@ -754,18 +757,21 @@ void STM32_CAN::disableMBInterrupts()
     HAL_NVIC_DisableIRQ(CAN1_IRQn_AIO);
     #else
     HAL_NVIC_DisableIRQ(CAN1_TX_IRQn);
+    HAL_NVIC_DisableIRQ(CAN1_RX0_IRQn);
     #endif /** else defined(CAN1_IRQn_AIO) */
   }
 #ifdef CAN2
   else if (n_pCanHandle->Instance == CAN2)
   {
     HAL_NVIC_DisableIRQ(CAN2_TX_IRQn);
+    HAL_NVIC_DisableIRQ(CAN2_RX0_IRQn);
   }
 #endif
 #ifdef CAN3
   else if (n_pCanHandle->Instance == CAN3)
   {
     HAL_NVIC_DisableIRQ(CAN3_TX_IRQn);
+    HAL_NVIC_DisableIRQ(CAN3_RX0_IRQn);
   }
 #endif
 }

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -193,7 +193,10 @@ void STM32_CAN::begin( bool retransmission ) {
   initializeBuffers();
   
   pin_function(rx, pinmap_function(rx, PinMap_CAN_RD));
-  pin_function(tx, pinmap_function(tx, PinMap_CAN_TD));
+  if(tx != NC)
+  {
+    pin_function(tx, pinmap_function(tx, PinMap_CAN_TD));
+  }
 
   // Configure CAN
   if (_can.handle.Instance == CAN1)

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -254,6 +254,11 @@ CAN_TypeDef * STM32_CAN::getPeripheral()
   return canPort_rx;
 }
 
+/**-------------------------------------------------------------
+ *     setup functions
+ *     no effect after begin()
+ * -------------------------------------------------------------
+ */
 void STM32_CAN::setIRQPriority(uint32_t preemptPriority, uint32_t subPriority)
 {
   //NOTE: limiting the IRQ prio, but not accounting for group setting
@@ -261,6 +266,28 @@ void STM32_CAN::setIRQPriority(uint32_t preemptPriority, uint32_t subPriority)
   this->subPriority = min(subPriority, MAX_IRQ_PRIO_VALUE);
 }
 
+void STM32_CAN::setMode(Mode mode)
+{
+  _can.handle.Init.Mode = mode;
+}
+
+void STM32_CAN::enableLoopBack( bool yes ) {
+  setMode(yes ? Mode::LOOPBACK : Mode::NORMAL);
+}
+
+void STM32_CAN::enableSilentMode( bool yes ) {
+  setMode(yes ? Mode::SILENT : Mode::NORMAL);
+}
+
+void STM32_CAN::enableSilentLoopBack( bool yes ) {
+  setMode(yes ? Mode::SILENT_LOOPBACK : Mode::NORMAL);
+}
+
+/**-------------------------------------------------------------
+ *     lifecycle functions
+ *     setBaudRate may be called before or after begin
+ * -------------------------------------------------------------
+ */
 // Init and start CAN
 void STM32_CAN::begin( bool retransmission ) {
 
@@ -457,6 +484,12 @@ void STM32_CAN::stop()
   /** Calls Stop internally, clears all errors */
   HAL_CAN_DeInit( &_can.handle );
 }
+
+
+/**-------------------------------------------------------------
+ *     post begin(), setup filters, data transfer
+ * -------------------------------------------------------------
+ */
 
 bool STM32_CAN::write(CAN_message_t &CAN_tx_msg, bool sendMB)
 {
@@ -713,6 +746,12 @@ bool STM32_CAN::setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint3
     return 0;
   }
 }
+
+
+/**-------------------------------------------------------------
+ *     Teensy FlexCAN compatibility functions
+ * -------------------------------------------------------------
+ */
 
 void STM32_CAN::setMBFilter(CAN_BANK bank_num, CAN_FLTEN input)
 {
@@ -1121,23 +1160,6 @@ void STM32_CAN::disableMBInterrupts()
     HAL_NVIC_DisableIRQ(CAN3_RX0_IRQn);
   }
 #endif
-}
-
-void STM32_CAN::setMode(Mode mode)
-{
-  _can.handle.Init.Mode = mode;
-}
-
-void STM32_CAN::enableLoopBack( bool yes ) {
-  setMode(yes ? Mode::LOOPBACK : Mode::NORMAL);
-}
-
-void STM32_CAN::enableSilentMode( bool yes ) {
-  setMode(yes ? Mode::SILENT : Mode::NORMAL);
-}
-
-void STM32_CAN::enableSilentLoopBack( bool yes ) {
-  setMode(yes ? Mode::SILENT_LOOPBACK : Mode::NORMAL);
 }
 
 void STM32_CAN::enableFIFO(bool status)

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -208,6 +208,11 @@ void STM32_CAN::init(void)
   baudrate = 0UL;
   filtersInitialized = false;
 
+  _can.handle.Init.TimeTriggeredMode = DISABLE;
+  _can.handle.Init.AutoBusOff = DISABLE;
+  _can.handle.Init.AutoWakeUp = DISABLE;
+  _can.handle.Init.ReceiveFifoLocked  = DISABLE;
+  _can.handle.Init.TransmitFifoPriority = ENABLE;
   _can.handle.Init.Mode = Mode::NORMAL;
 }
 
@@ -347,13 +352,8 @@ void STM32_CAN::begin( bool retransmission ) {
   }
 #endif
 
-  _can.handle.Init.TimeTriggeredMode = DISABLE;
-  _can.handle.Init.AutoBusOff = DISABLE;
-  _can.handle.Init.AutoWakeUp = DISABLE;
   if (retransmission){ _can.handle.Init.AutoRetransmission  = ENABLE; }
   else { _can.handle.Init.AutoRetransmission  = DISABLE; }
-  _can.handle.Init.ReceiveFifoLocked  = DISABLE;
-  _can.handle.Init.TransmitFifoPriority = ENABLE;
   
   filtersInitialized = false;
 

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -566,6 +566,23 @@ bool STM32_CAN::read(CAN_message_t &CAN_rx_msg)
   return ret;
 }
 
+uint8_t STM32_CAN::getFilterBankCount(IDE std_ext)
+{
+  (void)std_ext;
+  if(_can.handle.Instance == nullptr) return 0;
+  #ifdef CAN2
+  if(_can.handle.Instance == CAN1)
+  {
+    return STM32_CAN_CAN2_FILTER_OFFSET;
+  }
+  if(_can.handle.Instance == CAN2)
+  {
+    return STM32_CAN_DUAL_CAN_FILTER_COUNT - STM32_CAN_CAN2_FILTER_OFFSET;
+  }
+  #endif
+  return STM32_CAN_SINGLE_CAN_FILTER_COUNT;
+}
+
 static uint32_t format32bitFilter(uint32_t id, IDE std_ext, bool mask)
 {
   uint32_t id_reg;

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -117,7 +117,7 @@ bool STM32_CAN::hasPeripheral()
 
 STM32_CAN::STM32_CAN(uint32_t rx, uint32_t tx, RXQUEUE_TABLE rxSize, TXQUEUE_TABLE txSize)
   : sizeRxBuffer(rxSize), sizeTxBuffer(txSize),
-    mode(Mode::NORMAL), preemptPriority(MAX_IRQ_PRIO_VALUE), subPriority(0)
+    preemptPriority(MAX_IRQ_PRIO_VALUE), subPriority(0)
 {
   this->rx = digitalPinToPinName(rx);
   this->tx = digitalPinToPinName(tx);
@@ -126,14 +126,14 @@ STM32_CAN::STM32_CAN(uint32_t rx, uint32_t tx, RXQUEUE_TABLE rxSize, TXQUEUE_TAB
 
 STM32_CAN::STM32_CAN(PinName rx, PinName tx, RXQUEUE_TABLE rxSize, TXQUEUE_TABLE txSize)
   : rx(rx), tx(tx), sizeRxBuffer(rxSize), sizeTxBuffer(txSize),
-    mode(Mode::NORMAL), preemptPriority(MAX_IRQ_PRIO_VALUE), subPriority(0)
+    preemptPriority(MAX_IRQ_PRIO_VALUE), subPriority(0)
 {
   init();
 }
 
 STM32_CAN::STM32_CAN( CAN_TypeDef* canPort, RXQUEUE_TABLE rxSize, TXQUEUE_TABLE txSize )
   : sizeRxBuffer(rxSize), sizeTxBuffer(txSize),
-    mode(Mode::NORMAL), preemptPriority(MAX_IRQ_PRIO_VALUE), subPriority(0)
+    preemptPriority(MAX_IRQ_PRIO_VALUE), subPriority(0)
 {
   //get first matching pins from map
   rx = pinmap_find_pin(canPort, PinMap_CAN_RD);
@@ -144,7 +144,7 @@ STM32_CAN::STM32_CAN( CAN_TypeDef* canPort, RXQUEUE_TABLE rxSize, TXQUEUE_TABLE 
 //lagacy pin config for compatibility
 STM32_CAN::STM32_CAN( CAN_TypeDef* canPort, CAN_PINS pins, RXQUEUE_TABLE rxSize, TXQUEUE_TABLE txSize )
   : rx(NC), tx(NC), sizeRxBuffer(rxSize), sizeTxBuffer(txSize),
-    mode(Mode::NORMAL), preemptPriority(MAX_IRQ_PRIO_VALUE), subPriority(0)
+    preemptPriority(MAX_IRQ_PRIO_VALUE), subPriority(0)
 {
   if (canPort == CAN1)
   {
@@ -207,6 +207,8 @@ void STM32_CAN::init(void)
   _can.handle.Instance = nullptr;
   baudrate = 0UL;
   filtersInitialized = false;
+
+  _can.handle.Init.Mode = Mode::NORMAL;
 }
 
 CAN_TypeDef * STM32_CAN::getPeripheral()
@@ -352,7 +354,6 @@ void STM32_CAN::begin( bool retransmission ) {
   else { _can.handle.Init.AutoRetransmission  = DISABLE; }
   _can.handle.Init.ReceiveFifoLocked  = DISABLE;
   _can.handle.Init.TransmitFifoPriority = ENABLE;
-  _can.handle.Init.Mode = mode;
   
   filtersInitialized = false;
 
@@ -1068,7 +1069,6 @@ void STM32_CAN::disableMBInterrupts()
 
 void STM32_CAN::setMode(Mode mode)
 {
-  this->mode = mode;
   _can.handle.Init.Mode = mode;
 }
 

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -184,6 +184,7 @@ void STM32_CAN::init(void)
 {
   _can.__this = (void*)this;
   _can.handle.Instance = nullptr;
+  baudrate = 0UL;
 }
 
 CAN_TypeDef * STM32_CAN::getPeripheral()
@@ -312,10 +313,15 @@ void STM32_CAN::begin( bool retransmission ) {
   _can.handle.Init.ReceiveFifoLocked  = DISABLE;
   _can.handle.Init.TransmitFifoPriority = ENABLE;
   _can.handle.Init.Mode = mode;
+
+  //try to start in case baudrate was set earlier
+  setBaudRate(baudrate);
 }
 
 void STM32_CAN::setBaudRate(uint32_t baud)
 {
+  baudrate = baud;
+
   if(!hasPeripheral())
   {
     return;

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -70,9 +70,9 @@ can_index_t get_can_index(CAN_TypeDef *instance)
   return index;
 }
 
-bool STM32_CAN::allocatePeripheral()
+bool STM32_CAN::allocatePeripheral(CAN_TypeDef *instance)
 {
-  can_index_t index = get_can_index(_can.handle.Instance);
+  can_index_t index = get_can_index(instance);
   if(index >= CAN_NUM)
   {
     return false;
@@ -83,6 +83,7 @@ bool STM32_CAN::allocatePeripheral()
     Error_Handler();
     return false;
   }
+  _can.handle.Instance = instance;
   //register with global, we own this instance now
   canObj[index] = &_can;
   return true;
@@ -323,14 +324,13 @@ void STM32_CAN::begin( bool retransmission ) {
   // exit if CAN already is active
   if (_canIsActive) return;
 
-  _can.handle.Instance = getPeripheral();
-  if(_can.handle.Instance == NP)
+  auto instance = getPeripheral();
+  if(instance == NP)
   {
     //impossible pinconfig, done here
-    _can.handle.Instance = nullptr;
     return;
   }
-  if(!allocatePeripheral())
+  if(!allocatePeripheral(instance))
   {
     //peripheral already in use
     return;

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -90,6 +90,7 @@ bool STM32_CAN::allocatePeripheral()
 
 bool STM32_CAN::freePeripheral()
 {
+  if (_can.handle.Instance == nullptr) return false;
   can_index_t index = get_can_index(_can.handle.Instance);
   if(index >= CAN_NUM)
   {
@@ -107,6 +108,7 @@ bool STM32_CAN::freePeripheral()
 
 bool STM32_CAN::hasPeripheral()
 {
+  if (_can.handle.Instance == nullptr) return false;
   can_index_t index = get_can_index(_can.handle.Instance);
   if(index >= CAN_NUM)
   {

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -696,7 +696,7 @@ bool STM32_CAN::setFilter(uint8_t bank_num, uint32_t filter_id, uint32_t mask, I
   uint32_t id_reg   = format32bitFilter(filter_id, std_ext, false);
   uint32_t mask_reg = format32bitFilter(mask,      std_ext, true);
   FilterAction action = (fifo==CAN_FILTER_FIFO0) ? FilterAction::STORE_FIFO0 : FilterAction::STORE_FIFO1;
-  return setFilterRaw(bank_num, id_reg, mask_reg, filter_mode, filter_scale, action);
+  return !setFilterRaw(bank_num, id_reg, mask_reg, filter_mode, filter_scale, action);
 }
 
 bool STM32_CAN::setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint32_t filter_mode, uint32_t filter_scale, FilterAction action, bool enabled)
@@ -737,14 +737,7 @@ bool STM32_CAN::setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint3
   }
   #endif
   // Enable filter
-  if (HAL_CAN_ConfigFilter( &_can.handle, &sFilterConfig ) != HAL_OK)
-  {
-    return 1;
-  }
-  else
-  {
-    return 0;
-  }
+  return (HAL_CAN_ConfigFilter( &_can.handle, &sFilterConfig ) == HAL_OK);
 }
 
 
@@ -769,18 +762,18 @@ void STM32_CAN::setMBFilter(CAN_FLTEN input)
 bool STM32_CAN::setMBFilterProcessing(CAN_BANK bank_num, uint32_t filter_id, uint32_t mask, IDE std_ext)
 {
   // just convert the MB number enum to bank number.
-  return setFilterSingleMask(uint8_t(bank_num), filter_id, mask, std_ext);
+  return !setFilterSingleMask(uint8_t(bank_num), filter_id, mask, std_ext);
 }
 
 bool STM32_CAN::setMBFilter(CAN_BANK bank_num, uint32_t id1, IDE std_ext)
 {
   // by setting the mask to 0x1FFFFFFF we only filter the ID set as Filter ID.
-  return setFilterSingleMask(uint8_t(bank_num), id1, 0x1FFFFFFF, std_ext);
+  return !setFilterSingleMask(uint8_t(bank_num), id1, 0x1FFFFFFF, std_ext);
 }
 
 bool STM32_CAN::setMBFilter(CAN_BANK bank_num, uint32_t id1, uint32_t id2, IDE std_ext)
 {
-  return setFilterDualID(uint8_t(bank_num), id1, id2, std_ext, std_ext);
+  return !setFilterDualID(uint8_t(bank_num), id1, id2, std_ext, std_ext);
 }
 
 void STM32_CAN::initializeFilters()

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -994,37 +994,8 @@ bool STM32_CAN::calculateBaudrate(CAN_HandleTypeDef *CanHandle, int baud)
 
 uint32_t STM32_CAN::getAPB1Clock()
 {
-  RCC_ClkInitTypeDef clkInit;
-  uint32_t flashLatency;
-  HAL_RCC_GetClockConfig(&clkInit, &flashLatency);
-
-  uint32_t hclkClock = HAL_RCC_GetHCLKFreq();
-  uint8_t clockDivider = 1;
-  switch (clkInit.APB1CLKDivider)
-  {
-  case RCC_HCLK_DIV1:
-    clockDivider = 1;
-    break;
-  case RCC_HCLK_DIV2:
-    clockDivider = 2;
-    break;
-  case RCC_HCLK_DIV4:
-    clockDivider = 4;
-    break;
-  case RCC_HCLK_DIV8:
-    clockDivider = 8;
-    break;
-  case RCC_HCLK_DIV16:
-    clockDivider = 16;
-    break;
-  default:
-    // should not happen
-    break;
-  }
-
-  uint32_t apb1Clock = hclkClock / clockDivider;
-
-  return apb1Clock;
+  //APB1 is PCLK1
+  return HAL_RCC_GetPCLK1Freq();
 }
 
 void STM32_CAN::enableMBInterrupts()

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -716,48 +716,14 @@ bool STM32_CAN::setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint3
 
 void STM32_CAN::setMBFilter(CAN_BANK bank_num, CAN_FLTEN input)
 {
-  CAN_FilterTypeDef sFilterConfig;
-  if(!_can.handle.Instance) return;
-
-  sFilterConfig.FilterBank = uint8_t(bank_num);
-  #ifdef CAN2
-  sFilterConfig.SlaveStartFilterBank = STM32_CAN_CAN2_FILTER_OFFSET;
-  if (_can.handle.Instance == CAN2)
-  {
-    sFilterConfig.FilterBank += STM32_CAN_CAN2_FILTER_OFFSET;
-  }
-  #endif
-  if (input == ACCEPT_ALL) { sFilterConfig.FilterActivation = ENABLE; }
-  else { sFilterConfig.FilterActivation = DISABLE; }
-
-  HAL_CAN_ConfigFilter(&_can.handle, &sFilterConfig);
+  setFilter(bank_num, (input == ACCEPT_ALL));
 }
 
 void STM32_CAN::setMBFilter(CAN_FLTEN input)
 {
-  CAN_FilterTypeDef sFilterConfig;
-  uint8_t max_bank_num = STM32_CAN_SINGLE_CAN_FILTER_COUNT-1;
-  uint8_t min_bank_num = 0;
-  if(!_can.handle.Instance) return;
-  
-  #ifdef CAN2
-  sFilterConfig.SlaveStartFilterBank = STM32_CAN_CAN2_FILTER_OFFSET;
-  if (_can.handle.Instance == CAN1)
-  { 
-    max_bank_num = max(STM32_CAN_CAN2_FILTER_OFFSET-1, 0);
-  }
-  else if (_can.handle.Instance == CAN2)
+  for (uint8_t bank_num = 0 ; bank_num < STM32_CAN_SINGLE_CAN_FILTER_COUNT ; bank_num++)
   {
-    min_bank_num = STM32_CAN_CAN2_FILTER_OFFSET;
-    max_bank_num = STM32_CAN_DUAL_CAN_FILTER_COUNT-1;
-  }
-  #endif
-  for (uint8_t bank_num = min_bank_num ; bank_num <= max_bank_num ; bank_num++)
-  {
-    sFilterConfig.FilterBank = bank_num;
-    if (input == ACCEPT_ALL) { sFilterConfig.FilterActivation = ENABLE; }
-    else { sFilterConfig.FilterActivation = DISABLE; }
-    HAL_CAN_ConfigFilter(&_can.handle, &sFilterConfig);
+    setFilter(bank_num, (input == ACCEPT_ALL));
   }
 }
 

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -310,6 +310,7 @@ bool STM32_CAN::write(CAN_message_t &CAN_tx_msg, bool sendMB)
   bool ret = true;
   uint32_t TxMailbox;
   CAN_TxHeaderTypeDef TxHeader;
+  if(!_can.handle.Instance) return false;
 
   __HAL_CAN_DISABLE_IT(&_can.handle, CAN_IT_TX_MAILBOX_EMPTY);
 
@@ -356,6 +357,8 @@ bool STM32_CAN::write(CAN_message_t &CAN_tx_msg, bool sendMB)
 bool STM32_CAN::read(CAN_message_t &CAN_rx_msg)
 {
   bool ret;
+  if(!_can.handle.Instance) return false;
+
   #if defined(STM32_CAN1_TX_RX0_BLOCKED_BY_USB) && defined(STM32_CAN_USB_WORKAROUND_POLLING)
   __HAL_CAN_DISABLE_IT(&_can.handle, CAN_IT_RX_FIFO1_MSG_PENDING);
   #else
@@ -375,6 +378,7 @@ bool STM32_CAN::read(CAN_message_t &CAN_rx_msg)
 bool STM32_CAN::setFilter(uint8_t bank_num, uint32_t filter_id, uint32_t mask, IDE std_ext, uint32_t filter_mode, uint32_t filter_scale, uint32_t fifo)
 {
   CAN_FilterTypeDef sFilterConfig;
+  if(!_can.handle.Instance) return false;
 
   sFilterConfig.FilterBank = bank_num;
   sFilterConfig.FilterMode = filter_mode;
@@ -421,6 +425,8 @@ bool STM32_CAN::setFilter(uint8_t bank_num, uint32_t filter_id, uint32_t mask, I
 void STM32_CAN::setMBFilter(CAN_BANK bank_num, CAN_FLTEN input)
 {
   CAN_FilterTypeDef sFilterConfig;
+  if(!_can.handle.Instance) return;
+
   sFilterConfig.FilterBank = uint8_t(bank_num);
   if (input == ACCEPT_ALL) { sFilterConfig.FilterActivation = ENABLE; }
   else { sFilterConfig.FilterActivation = DISABLE; }
@@ -433,6 +439,8 @@ void STM32_CAN::setMBFilter(CAN_FLTEN input)
   CAN_FilterTypeDef sFilterConfig;
   uint8_t max_bank_num = 27;
   uint8_t min_bank_num = 0;
+  if(!_can.handle.Instance) return;
+  
   #ifdef CAN2
   if (_can.handle.Instance == CAN1){ max_bank_num = 13;}
   else if (_can.handle.Instance == CAN2){ min_bank_num = 14;}
@@ -468,6 +476,8 @@ bool STM32_CAN::setMBFilter(CAN_BANK bank_num, uint32_t id1, uint32_t id2, IDE s
 void STM32_CAN::initializeFilters()
 {
   CAN_FilterTypeDef sFilterConfig;
+  if(!_can.handle.Instance) return;
+  
   // We set first bank to accept all RX messages
   sFilterConfig.FilterBank = 0;
   sFilterConfig.FilterMode = CAN_FILTERMODE_IDMASK;

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -213,7 +213,7 @@ void STM32_CAN::init(void)
   _can.handle.Init.AutoWakeUp = DISABLE;
   _can.handle.Init.ReceiveFifoLocked  = DISABLE;
   _can.handle.Init.TransmitFifoPriority = ENABLE;
-  _can.handle.Init.Mode = Mode::NORMAL;
+  _can.handle.Init.Mode = MODE::NORMAL;
 }
 
 CAN_TypeDef * STM32_CAN::getPeripheral()
@@ -266,21 +266,21 @@ void STM32_CAN::setIRQPriority(uint32_t preemptPriority, uint32_t subPriority)
   this->subPriority = min(subPriority, MAX_IRQ_PRIO_VALUE);
 }
 
-void STM32_CAN::setMode(Mode mode)
+void STM32_CAN::setMode(MODE mode)
 {
   _can.handle.Init.Mode = mode;
 }
 
 void STM32_CAN::enableLoopBack( bool yes ) {
-  setMode(yes ? Mode::LOOPBACK : Mode::NORMAL);
+  setMode(yes ? MODE::LOOPBACK : MODE::NORMAL);
 }
 
 void STM32_CAN::enableSilentMode( bool yes ) {
-  setMode(yes ? Mode::SILENT : Mode::NORMAL);
+  setMode(yes ? MODE::SILENT : MODE::NORMAL);
 }
 
 void STM32_CAN::enableSilentLoopBack( bool yes ) {
-  setMode(yes ? Mode::SILENT_LOOPBACK : Mode::NORMAL);
+  setMode(yes ? MODE::SILENT_LOOPBACK : MODE::NORMAL);
 }
 
 /**-------------------------------------------------------------
@@ -626,7 +626,7 @@ static uint32_t format16bitFilter(uint32_t id, IDE std_ext, bool mask)
   return id_reg;
 }
 
-bool STM32_CAN::setFilter(uint8_t bank_num, bool enabled, FilterAction action)
+bool STM32_CAN::setFilter(uint8_t bank_num, bool enabled, FILTER_ACTION action)
 {
   CAN_TypeDef *can_ip = _can.handle.Instance;
   if(!_can.handle.Instance) return false;
@@ -653,10 +653,10 @@ bool STM32_CAN::setFilter(uint8_t bank_num, bool enabled, FilterAction action)
   /* Filter FIFO assignment */
   switch (action)
   {
-    case FilterAction::STORE_FIFO0:
+    case FILTER_ACTION::STORE_FIFO0:
       CLEAR_BIT(can_ip->FFA1R, filternbrbitpos);
       break;
-    case FilterAction::STORE_FIFO1:
+    case FILTER_ACTION::STORE_FIFO1:
       SET_BIT(can_ip->FFA1R, filternbrbitpos);
       break;
   }
@@ -671,28 +671,28 @@ bool STM32_CAN::setFilter(uint8_t bank_num, bool enabled, FilterAction action)
   return true;
 }
 
-bool STM32_CAN::setFilterSingleMask(uint8_t bank_num, uint32_t id, uint32_t mask, IDE std_ext, FilterAction action, bool enabled)
+bool STM32_CAN::setFilterSingleMask(uint8_t bank_num, uint32_t id, uint32_t mask, IDE std_ext, FILTER_ACTION action, bool enabled)
 {
   uint32_t id_reg   = format32bitFilter(id,   std_ext, false);
   uint32_t mask_reg = format32bitFilter(mask, std_ext, true);
   return setFilterRaw(bank_num, id_reg, mask_reg, CAN_FILTERMODE_IDMASK, CAN_FILTERSCALE_32BIT, action, enabled);
 }
 
-bool STM32_CAN::setFilterDualID(uint8_t bank_num, uint32_t id1, uint32_t id2, IDE std_ext1, IDE std_ext2, FilterAction action, bool enabled)
+bool STM32_CAN::setFilterDualID(uint8_t bank_num, uint32_t id1, uint32_t id2, IDE std_ext1, IDE std_ext2, FILTER_ACTION action, bool enabled)
 {
   uint32_t id   = format32bitFilter(id1, std_ext1, false);
   uint32_t mask = format32bitFilter(id2, std_ext2, false);
   return setFilterRaw(bank_num, id, mask, CAN_FILTERMODE_IDLIST, CAN_FILTERSCALE_32BIT, action, enabled);
 }
 
-bool STM32_CAN::setFilterDualMask(uint8_t bank_num, uint32_t id1, uint32_t mask1, IDE std_ext1, uint32_t id2, uint32_t mask2, IDE std_ext2, FilterAction action, bool enabled)
+bool STM32_CAN::setFilterDualMask(uint8_t bank_num, uint32_t id1, uint32_t mask1, IDE std_ext1, uint32_t id2, uint32_t mask2, IDE std_ext2, FILTER_ACTION action, bool enabled)
 {
   uint32_t id   = (uint32_t)format16bitFilter(id1, std_ext1, false) | (((uint32_t)format16bitFilter(mask1, std_ext1, true)) << 16);
   uint32_t mask = (uint32_t)format16bitFilter(id2, std_ext2, false) | (((uint32_t)format16bitFilter(mask2, std_ext2, true)) << 16);
   return setFilterRaw(bank_num, id, mask, CAN_FILTERMODE_IDMASK, CAN_FILTERSCALE_16BIT, action, enabled);
 }
 
-bool STM32_CAN::setFilterQuadID(uint8_t bank_num, uint32_t id1, IDE std_ext1, uint32_t id2, IDE std_ext2, uint32_t id3, IDE std_ext3, uint32_t id4, IDE std_ext4, FilterAction action, bool enabled)
+bool STM32_CAN::setFilterQuadID(uint8_t bank_num, uint32_t id1, IDE std_ext1, uint32_t id2, IDE std_ext2, uint32_t id3, IDE std_ext3, uint32_t id4, IDE std_ext4, FILTER_ACTION action, bool enabled)
 {
   uint32_t id   = (uint32_t)format16bitFilter(id1, std_ext1, false) | (((uint32_t)format16bitFilter(id2, std_ext2, false)) << 16);
   uint32_t mask = (uint32_t)format16bitFilter(id3, std_ext3, false) | (((uint32_t)format16bitFilter(id4, std_ext4, false)) << 16);
@@ -713,11 +713,11 @@ bool STM32_CAN::setFilter(uint8_t bank_num, uint32_t filter_id, uint32_t mask, I
   /** re-implement broken implementation for legacy behaviour */
   uint32_t id_reg   = format32bitFilter(filter_id, std_ext, false);
   uint32_t mask_reg = format32bitFilter(mask,      std_ext, true);
-  FilterAction action = (fifo==CAN_FILTER_FIFO0) ? FilterAction::STORE_FIFO0 : FilterAction::STORE_FIFO1;
+  FILTER_ACTION action = (fifo==CAN_FILTER_FIFO0) ? FILTER_ACTION::STORE_FIFO0 : FILTER_ACTION::STORE_FIFO1;
   return !setFilterRaw(bank_num, id_reg, mask_reg, filter_mode, filter_scale, action);
 }
 
-bool STM32_CAN::setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint32_t filter_mode, uint32_t filter_scale, FilterAction action, bool enabled)
+bool STM32_CAN::setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint32_t filter_mode, uint32_t filter_scale, FILTER_ACTION action, bool enabled)
 {
   CAN_FilterTypeDef sFilterConfig;
   if(!_can.handle.Instance) return false;
@@ -726,17 +726,17 @@ bool STM32_CAN::setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint3
   sFilterConfig.FilterMode = filter_mode;
   sFilterConfig.FilterScale = filter_scale;
   #if defined(STM32_CAN1_TX_RX0_BLOCKED_BY_USB) && defined(STM32_CAN_USB_WORKAROUND_POLLING)
-  if(action == FilterAction::STORE_FIFO0)
+  if(action == FILTER_ACTION::STORE_FIFO0)
   {
     core_debug("WARNING: RX0 IRQ is blocked by USB Driver. Events only handled by polling and RX1 events!\n");
   }
   #endif
   switch (action)
   {
-    case FilterAction::STORE_FIFO0:
+    case FILTER_ACTION::STORE_FIFO0:
       sFilterConfig.FilterFIFOAssignment = CAN_FILTER_FIFO0;
       break;
-    case FilterAction::STORE_FIFO1:
+    case FILTER_ACTION::STORE_FIFO1:
       sFilterConfig.FilterFIFOAssignment = CAN_FILTER_FIFO1;
       break;
   }
@@ -808,7 +808,7 @@ void STM32_CAN::initializeFilters()
 
   /** Let everything in by default */
   setFilterRaw(0, 0UL, 0UL, CAN_FILTERMODE_IDMASK, CAN_FILTERSCALE_32BIT,
-    FilterAction::CAN_FILTER_DEFAULT_ACTION, true);
+    FILTER_ACTION::CAN_FILTER_DEFAULT_ACTION, true);
 
   /** turn off all other filters that might sill be setup from before */
   for (uint8_t bank_num = 1 ; bank_num < STM32_CAN_SINGLE_CAN_FILTER_COUNT ; bank_num++)

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -760,11 +760,7 @@ void STM32_CAN::initializeFilters()
   sFilterConfig.FilterIdLow = 0x0000;
   sFilterConfig.FilterMaskIdHigh = 0x0000;
   sFilterConfig.FilterMaskIdLow = 0x0000;
-  #if defined(STM32_CAN1_TX_RX0_BLOCKED_BY_USB) && defined(STM32_CAN_USB_WORKAROUND_POLLING)
-  sFilterConfig.FilterFIFOAssignment = CAN_RX_FIFO1;
-  #else
-  sFilterConfig.FilterFIFOAssignment = CAN_RX_FIFO0;
-  #endif
+  sFilterConfig.FilterFIFOAssignment = CAN_FILTER_DEFAULT_FIFO;
   sFilterConfig.FilterActivation = ENABLE;
   #ifdef CAN2
   // Filter banks from 14 to 27 are for Can2, so first for Can2 is bank 14. This is not relevant for devices with only one CAN

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -345,7 +345,15 @@ void STM32_CAN::begin( bool retransmission ) {
 
   initializeBuffers();
   
-  pin_function(rx, pinmap_function(rx, PinMap_CAN_RD));
+  /**
+   * NOTE: enabling the internal pullup of RX pin
+   * in case no external circuitry (CAN Transceiver) is connected this will ensure a valid recessive level.
+   * A valid recessive level on RX is needed to leave init mode and enter normal mode.
+   * This is even the case if loopback is enabled where the input is internally connected.
+   * This lets loopback only tests without external circuitry sill function.
+   */
+  uint32_t rx_func = pinmap_function(rx, PinMap_CAN_RD);
+  pin_function(rx, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, STM_PIN_AFNUM(rx_func)));
   if(tx != NC)
   {
     pin_function(tx, pinmap_function(tx, PinMap_CAN_TD));

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -612,6 +612,7 @@ static uint32_t format16bitFilter(uint32_t id, IDE std_ext, bool mask)
 bool STM32_CAN::setFilter(uint8_t bank_num, bool enabled, FilterAction action)
 {
   CAN_TypeDef *can_ip = _can.handle.Instance;
+  if(!_can.handle.Instance) return false;
   /** CAN2 shares filter banks with CAN1
    * Driver allocates equal amount to each
    * Filter Banks located at CAN1 base address

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -16,13 +16,15 @@ static CAN_HandleTypeDef     hcan3;
 #endif
 
 STM32_CAN::STM32_CAN(PinName rx, PinName tx, RXQUEUE_TABLE rxSize, TXQUEUE_TABLE txSize)
-  : rx(rx), tx(tx), sizeRxBuffer(rxSize), sizeTxBuffer(txSize)
+  : rx(rx), tx(tx), sizeRxBuffer(rxSize), sizeTxBuffer(txSize),
+    mode(Mode::NORMAL)
 {
   init();
 }
 
 STM32_CAN::STM32_CAN( CAN_TypeDef* canPort, RXQUEUE_TABLE rxSize, TXQUEUE_TABLE txSize )
-  : sizeRxBuffer(rxSize), sizeTxBuffer(txSize)
+  : sizeRxBuffer(rxSize), sizeTxBuffer(txSize),
+    mode(Mode::NORMAL)
 {
   //get first matching pins from map
   rx = pinmap_find_pin(canPort, PinMap_CAN_RD);
@@ -32,7 +34,8 @@ STM32_CAN::STM32_CAN( CAN_TypeDef* canPort, RXQUEUE_TABLE rxSize, TXQUEUE_TABLE 
 
 //lagacy pin config for compatibility
 STM32_CAN::STM32_CAN( CAN_TypeDef* canPort, CAN_PINS pins, RXQUEUE_TABLE rxSize, TXQUEUE_TABLE txSize )
-  : rx(NC), tx(NC), sizeRxBuffer(rxSize), sizeTxBuffer(txSize)
+  : rx(NC), tx(NC), sizeRxBuffer(rxSize), sizeTxBuffer(txSize),
+    mode(Mode::NORMAL)
 {
   if (canPort == CAN1)
   {
@@ -199,7 +202,7 @@ void STM32_CAN::begin( bool retransmission ) {
   else { n_pCanHandle->Init.AutoRetransmission  = DISABLE; }
   n_pCanHandle->Init.ReceiveFifoLocked  = DISABLE;
   n_pCanHandle->Init.TransmitFifoPriority = ENABLE;
-  n_pCanHandle->Init.Mode = CAN_MODE_NORMAL;
+  n_pCanHandle->Init.Mode = mode;
 }
 
 void STM32_CAN::setBaudRate(uint32_t baud)
@@ -743,19 +746,22 @@ void STM32_CAN::disableMBInterrupts()
 #endif
 }
 
+void STM32_CAN::setMode(Mode mode)
+{
+  this->mode = mode;
+  n_pCanHandle->Init.Mode = mode;
+}
+
 void STM32_CAN::enableLoopBack( bool yes ) {
-  if (yes) { n_pCanHandle->Init.Mode = CAN_MODE_LOOPBACK; }
-  else { n_pCanHandle->Init.Mode = CAN_MODE_NORMAL; }
+  setMode(yes ? Mode::LOOPBACK : Mode::NORMAL);
 }
 
 void STM32_CAN::enableSilentMode( bool yes ) {
-  if (yes) { n_pCanHandle->Init.Mode = CAN_MODE_SILENT; }
-  else { n_pCanHandle->Init.Mode = CAN_MODE_NORMAL; }
+  setMode(yes ? Mode::SILENT : Mode::NORMAL);
 }
 
 void STM32_CAN::enableSilentLoopBack( bool yes ) {
-  if (yes) { n_pCanHandle->Init.Mode = CAN_MODE_SILENT_LOOPBACK; }
-  else { n_pCanHandle->Init.Mode = CAN_MODE_NORMAL; }
+  setMode(yes ? Mode::SILENT_LOOPBACK : Mode::NORMAL);
 }
 
 void STM32_CAN::enableFIFO(bool status)

--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -698,6 +698,10 @@ bool STM32_CAN::setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint3
 
   #ifdef CAN2
   sFilterConfig.SlaveStartFilterBank = STM32_CAN_CAN2_FILTER_OFFSET;
+  if(_can.handle.Instance == CAN2)
+  {
+    sFilterConfig.FilterBank += STM32_CAN_CAN2_FILTER_OFFSET;
+  }
   #endif
   // Enable filter
   if (HAL_CAN_ConfigFilter( &_can.handle, &sFilterConfig ) != HAL_OK)

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -135,6 +135,11 @@ to same folder with sketch and haven #define HAL_CAN_MODULE_ENABLED there. See e
 #elif defined(USBCON) && defined(STM32_CAN_USB_WORKAROUND_POLLING)
 #warning "CAN IRQ Handler is used by USBDevice driver, call STM32_CAN_Poll_IRQ_Handler() frequently to handle CAN events."
 extern "C" void STM32_CAN_Poll_IRQ_Handler(void);
+#define CAN_FILTER_DEFAULT_FIFO   CAN_FILTER_FIFO1
+#define CAN_FILTER_DEFAULT_ACTION STORE_FIFO1
+#else
+#define CAN_FILTER_DEFAULT_FIFO   CAN_FILTER_FIFO0
+#define CAN_FILTER_DEFAULT_ACTION STORE_FIFO0
 #endif
 
 
@@ -267,14 +272,14 @@ class STM32_CAN {
       STORE_FIFO1
     };
     /** set filter state and action, keeps filter rules intact */
-    bool setFilter(uint8_t bank_num, bool state, FilterAction action = STORE_FIFO0);
-    bool setFilterSingleMask(uint8_t bank_num, uint32_t id, uint32_t mask, IDE std_ext, FilterAction action = STORE_FIFO0, bool enabled = true);
-    bool setFilterDualID(uint8_t bank_num, uint32_t id1, uint32_t id2, IDE std_ext1, IDE std_ext2, FilterAction action = STORE_FIFO0, bool enabled = true);
-    bool setFilterDualMask(uint8_t bank_num, uint32_t id1, uint32_t mask1, IDE std_ext1, uint32_t id2, uint32_t mask2, IDE std_ext2, FilterAction action = STORE_FIFO0, bool enabled = true);
-    bool setFilterQuadID(uint8_t bank_num, uint32_t id1, IDE std_ext1, uint32_t id2, IDE std_ext2, uint32_t id3, IDE std_ext3, uint32_t id4, IDE std_ext4, FilterAction action = STORE_FIFO0, bool enabled = true);
-    bool setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint32_t filter_mode, uint32_t filter_scale, FilterAction action = STORE_FIFO0, bool enabled = true);
+    bool setFilter(uint8_t bank_num, bool state, FilterAction action = CAN_FILTER_DEFAULT_ACTION);
+    bool setFilterSingleMask(uint8_t bank_num, uint32_t id, uint32_t mask, IDE std_ext, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
+    bool setFilterDualID(uint8_t bank_num, uint32_t id1, uint32_t id2, IDE std_ext1, IDE std_ext2, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
+    bool setFilterDualMask(uint8_t bank_num, uint32_t id1, uint32_t mask1, IDE std_ext1, uint32_t id2, uint32_t mask2, IDE std_ext2, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
+    bool setFilterQuadID(uint8_t bank_num, uint32_t id1, IDE std_ext1, uint32_t id2, IDE std_ext2, uint32_t id3, IDE std_ext3, uint32_t id4, IDE std_ext4, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
+    bool setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint32_t filter_mode, uint32_t filter_scale, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
     // Legacy, broken! Only works correctly for 32 bit mask mode
-    bool setFilter(uint8_t bank_num, uint32_t filter_id, uint32_t mask, IDE = AUTO, uint32_t filter_mode = CAN_FILTERMODE_IDMASK, uint32_t filter_scale = CAN_FILTERSCALE_32BIT, uint32_t fifo = CAN_FILTER_FIFO0);
+    bool setFilter(uint8_t bank_num, uint32_t filter_id, uint32_t mask, IDE = AUTO, uint32_t filter_mode = CAN_FILTERMODE_IDMASK, uint32_t filter_scale = CAN_FILTERSCALE_32BIT, uint32_t fifo = CAN_FILTER_DEFAULT_FIFO);
     // Teensy FlexCAN style "set filter" -functions
     bool setMBFilterProcessing(CAN_BANK bank_num, uint32_t filter_id, uint32_t mask, IDE = AUTO);
     void setMBFilter(CAN_FLTEN input); /* enable/disable traffic for all MBs (for individual masking) */

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -239,6 +239,12 @@ typedef enum IDE {
   AUTO = 2
 } IDE;
 
+typedef struct {
+  void * __this;
+  CAN_HandleTypeDef handle;
+  uint32_t bus;
+} stm32_can_t;
+
 class STM32_CAN {
 
   public:
@@ -364,8 +370,7 @@ class STM32_CAN {
     uint32_t preemptPriority;
     uint32_t subPriority;
 
-    CAN_HandleTypeDef *n_pCanHandle;
-    CAN_TypeDef*      _canPort;
+    stm32_can_t _can;
 
 };
 

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -243,6 +243,7 @@ class STM32_CAN {
 
   public:
     // Default buffer sizes are set to 16. But this can be changed by using constructor in main code.
+    STM32_CAN(uint32_t rx, uint32_t tx = PNUM_NOT_DEFINED, RXQUEUE_TABLE rxSize = RX_SIZE_16, TXQUEUE_TABLE txSize = TX_SIZE_16);
     STM32_CAN(PinName rx, PinName tx = NC, RXQUEUE_TABLE rxSize = RX_SIZE_16, TXQUEUE_TABLE txSize = TX_SIZE_16);
     STM32_CAN(CAN_TypeDef* canPort, RXQUEUE_TABLE rxSize = RX_SIZE_16, TXQUEUE_TABLE txSize = TX_SIZE_16);
     //legacy for compatibility

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -142,6 +142,9 @@ class STM32_CAN {
 
   public:
     // Default buffer sizes are set to 16. But this can be changed by using constructor in main code.
+    STM32_CAN(PinName rx, PinName tx = NC, RXQUEUE_TABLE rxSize = RX_SIZE_16, TXQUEUE_TABLE txSize = TX_SIZE_16);
+    STM32_CAN(CAN_TypeDef* canPort, RXQUEUE_TABLE rxSize = RX_SIZE_16, TXQUEUE_TABLE txSize = TX_SIZE_16);
+    //legacy for compatibility
     STM32_CAN(CAN_TypeDef* canPort, CAN_PINS pins, RXQUEUE_TABLE rxSize = RX_SIZE_16, TXQUEUE_TABLE txSize = TX_SIZE_16);
     // Begin. By default the automatic retransmission is enabled. If it causes problems, use begin(false) to disable it.
     void begin(bool retransmission = false);
@@ -183,6 +186,7 @@ class STM32_CAN {
     uint16_t sizeTxBuffer;
 
   private:
+    void      init(void);
     void      initializeFilters();
     bool      isInitialized() { return rx_buffer != 0; }
     void      initRingBuffer(RingbufferTypeDef &ring, volatile CAN_message_t *buffer, uint32_t size);
@@ -240,7 +244,9 @@ class STM32_CAN {
     };
 
     bool     _canIsActive = false;
-    CAN_PINS _pins;
+
+    PinName rx;
+    PinName tx;
 
     CAN_HandleTypeDef *n_pCanHandle;
     CAN_TypeDef*      _canPort;

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -301,7 +301,10 @@ class STM32_CAN {
     bool write(CAN_message_t &CAN_tx_msg, bool sendMB = false);
     bool read(CAN_message_t &CAN_rx_msg);
 
-    // Manually set STM32 filter bank parameters
+    /** 
+     * Manually set STM32 filter bank parameters
+     * These return true on success
+     */
     /** set filter state and action, keeps filter rules intact */
     bool setFilter(uint8_t bank_num, bool state, FilterAction action = CAN_FILTER_DEFAULT_ACTION);
     bool setFilterSingleMask(uint8_t bank_num, uint32_t id, uint32_t mask, IDE std_ext, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
@@ -309,12 +312,15 @@ class STM32_CAN {
     bool setFilterDualMask(uint8_t bank_num, uint32_t id1, uint32_t mask1, IDE std_ext1, uint32_t id2, uint32_t mask2, IDE std_ext2, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
     bool setFilterQuadID(uint8_t bank_num, uint32_t id1, IDE std_ext1, uint32_t id2, IDE std_ext2, uint32_t id3, IDE std_ext3, uint32_t id4, IDE std_ext4, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
     bool setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint32_t filter_mode, uint32_t filter_scale, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
-    // Legacy, broken! Only works correctly for 32 bit mask mode
+    /** Legacy, broken! Only works correctly for 32 bit mask mode 
+     * Retruns true on Error, false on Success (like Teensy functions, opposite of STM32 function)
+    */
     bool setFilter(uint8_t bank_num, uint32_t filter_id, uint32_t mask, IDE = AUTO, uint32_t filter_mode = CAN_FILTERMODE_IDMASK, uint32_t filter_scale = CAN_FILTERSCALE_32BIT, uint32_t fifo = CAN_FILTER_DEFAULT_FIFO);
 
 /**-------------------------------------------------------------
  *     Teensy FlexCAN compatibility functions
  * -------------------------------------------------------------
+ * These return false on success
  */
     bool setMBFilterProcessing(CAN_BANK bank_num, uint32_t filter_id, uint32_t mask, IDE = AUTO);
     void setMBFilter(CAN_FLTEN input); /* enable/disable traffic for all MBs (for individual masking) */

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -266,6 +266,8 @@ class STM32_CAN {
       STORE_FIFO0,
       STORE_FIFO1
     };
+    /** set filter state and action, keeps filter rules intact */
+    bool setFilter(uint8_t bank_num, bool state, FilterAction action = STORE_FIFO0);
     bool setFilterSingleMask(uint8_t bank_num, uint32_t id, uint32_t mask, IDE std_ext, FilterAction action = STORE_FIFO0, bool enabled = true);
     bool setFilterDualID(uint8_t bank_num, uint32_t id1, uint32_t id2, IDE std_ext1, IDE std_ext2, FilterAction action = STORE_FIFO0, bool enabled = true);
     bool setFilterDualMask(uint8_t bank_num, uint32_t id1, uint32_t mask1, IDE std_ext1, uint32_t id2, uint32_t mask2, IDE std_ext2, FilterAction action = STORE_FIFO0, bool enabled = true);

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -304,6 +304,9 @@ class STM32_CAN {
 
   private:
     void      init(void);
+    CAN_TypeDef * getPeripheral(void);
+    bool      allocatePeripheral(void);
+    bool      hasPeripheral(void);
     void      initializeFilters();
     bool      isInitialized() { return rx_buffer != 0; }
     void      initRingBuffer(RingbufferTypeDef &ring, volatile CAN_message_t *buffer, uint32_t size);

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -380,7 +380,7 @@ class STM32_CAN {
   private:
     void      init(void);
     CAN_TypeDef * getPeripheral(void);
-    bool      allocatePeripheral(void);
+    bool      allocatePeripheral(CAN_TypeDef *instance);
     bool      freePeripheral(void);
     bool      hasPeripheral(void);
     void      start(void);

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -337,10 +337,10 @@ class STM32_CAN {
     uint32_t  ringBufferCount(RingbufferTypeDef &ring);
 
     template <typename T, size_t N>
-    bool      lookupBaudrate(CAN_HandleTypeDef *CanHandle, int Baudrate, const T(&table)[N]);
-    bool      calculateBaudrate(CAN_HandleTypeDef *CanHandle, int Baudrate);
-    void      setBaudRateValues(CAN_HandleTypeDef *CanHandle, uint16_t prescaler, uint8_t timeseg1,
-                                                              uint8_t timeseg2, uint8_t sjw);
+    bool      lookupBaudrate(int Baudrate, const T(&table)[N]);
+    bool      calculateBaudrate(int Baudrate);
+    void      setBaudRateValues(uint16_t prescaler, uint8_t timeseg1,
+                                uint8_t timeseg2, uint8_t sjw);
     uint32_t  getCanPeripheralClock(void);
 
     volatile CAN_message_t *rx_buffer = nullptr;

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -62,6 +62,11 @@ to same folder with sketch and haven #define HAL_CAN_MODULE_ENABLED there. See e
  * CAN1_RX1_IRQn | CAN1_RX1_IRQHandler
  * CAN1_SCE_IRQn | CAN1_SCE_IRQHandler
  */
+
+#ifdef USBCON
+#define STM32_CAN1_TX_RX0_BLOCKED_BY_USB
+#endif
+
 #endif
 #endif
 
@@ -98,6 +103,10 @@ to same folder with sketch and haven #define HAL_CAN_MODULE_ENABLED there. See e
   #define CAN1_RX1_IRQHandler CAN_RX1_IRQHandler
   #define CAN1_SCE_IRQHandler CAN_SCE_IRQHandler
 
+  #ifdef USBCON
+  #define STM32_CAN1_TX_RX0_BLOCKED_BY_USB
+  #endif
+
 #elif defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8)\
  || defined(STM32F358xx) || defined(STM32F373xC)\
  || defined(STM32F378xx) || defined(STM32F398xx)
@@ -117,6 +126,10 @@ to same folder with sketch and haven #define HAL_CAN_MODULE_ENABLED there. See e
   #define CAN1_RX1_IRQHandler CAN_RX1_IRQHandler
   #define CAN1_SCE_IRQHandler CAN_SCE_IRQHandler
 #endif
+#endif
+
+#ifdef STM32_CAN1_TX_RX0_BLOCKED_BY_USB
+#error "USB and CAN interrupts are shared on the F1/F3 platform, driver is not compatible with USBDevice of Arduino core.
 #endif
 
 #include <Arduino.h>

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -19,6 +19,8 @@ to same folder with sketch and haven #define HAL_CAN_MODULE_ENABLED there. See e
 #ifndef STM32_CAN_H
 #define STM32_CAN_H
 
+#include <Arduino.h>
+
 /** Handling special cases for IRQ Handlers */
 #if defined(STM32F0xx)
 #if defined(STM32F042x6) || defined(STM32F072xB) || defined(STM32F091xC) || defined(STM32F098xx)
@@ -128,11 +130,13 @@ to same folder with sketch and haven #define HAL_CAN_MODULE_ENABLED there. See e
 #endif
 #endif
 
-#ifdef STM32_CAN1_TX_RX0_BLOCKED_BY_USB
-#error "USB and CAN interrupts are shared on the F1/F3 platform, driver is not compatible with USBDevice of Arduino core.
+#if defined(STM32_CAN1_TX_RX0_BLOCKED_BY_USB) && !defined(STM32_CAN_USB_WORKAROUND_POLLING)
+#error "USB and CAN interrupts are shared on the F1/F3 platform, driver is not compatible with USBDevice of Arduino core. Can define STM32_CAN_USB_WORKAROUND_POLLING to disable error msg and call STM32_CAN_Poll_IRQ_Handler to poll for Tx IRQ events. Only use FIFO 1."
+#elif defined(USBCON) && defined(STM32_CAN_USB_WORKAROUND_POLLING)
+#warning "CAN IRQ Handler is used by USBDevice driver, call STM32_CAN_Poll_IRQ_Handler() frequently to handle CAN events."
+extern "C" void STM32_CAN_Poll_IRQ_Handler(void);
 #endif
 
-#include <Arduino.h>
 
 // This struct is directly copied from Teensy FlexCAN library to retain compatibility with it. Not all are in use with STM32.
 // Source: https://github.com/tonton81/FlexCAN_T4/

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -265,6 +265,12 @@ class STM32_CAN {
       STORE_FIFO1,
     };
 
+    enum TX_BUFFER_MODE {
+      FIFO  = ENABLE, /** Sequencial transfers order */
+      QUEUE = DISABLE /** Sequence based on msg ID priorites. Only effects hardware queue. */
+    };
+
+
     // Default buffer sizes are set to 16. But this can be changed by using constructor in main code.
     STM32_CAN(uint32_t rx, uint32_t tx = PNUM_NOT_DEFINED, RXQUEUE_TABLE rxSize = RX_SIZE_16, TXQUEUE_TABLE txSize = TX_SIZE_16);
     STM32_CAN(PinName rx, PinName tx = NC, RXQUEUE_TABLE rxSize = RX_SIZE_16, TXQUEUE_TABLE txSize = TX_SIZE_16);
@@ -278,10 +284,22 @@ class STM32_CAN {
  */
     void setIRQPriority(uint32_t preemptPriority, uint32_t subPriority);
 
+    /** send message again on arbitration failure */
+    void setAutoRetransmission(bool enabled);
+
+    /** If locked incoming msg is dropped when fifo is full,
+     *  when unlocked last msg in fifo is overwritten
+     *  2nd arg has no effect, setting effects both fifos */
+    void setRxFIFOLock(bool fifo0locked, bool fifo1locked = true);
+    void setTxBufferMode(TX_BUFFER_MODE mode);
+    void setTimestampCounter(bool enabled);
+
     void setMode(MODE mode);
     void enableLoopBack(bool yes = 1);
     void enableSilentMode(bool yes = 1);
     void enableSilentLoopBack(bool yes = 1);
+
+    void setAutoBusOffRecovery(bool enabled);
 
 /**-------------------------------------------------------------
  *     lifecycle functions

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -146,6 +146,7 @@ class STM32_CAN {
     STM32_CAN(CAN_TypeDef* canPort, RXQUEUE_TABLE rxSize = RX_SIZE_16, TXQUEUE_TABLE txSize = TX_SIZE_16);
     //legacy for compatibility
     STM32_CAN(CAN_TypeDef* canPort, CAN_PINS pins, RXQUEUE_TABLE rxSize = RX_SIZE_16, TXQUEUE_TABLE txSize = TX_SIZE_16);
+    void setIRQPriority(uint32_t preemptPriority, uint32_t subPriority);
     // Begin. By default the automatic retransmission is enabled. If it causes problems, use begin(false) to disable it.
     void begin(bool retransmission = false);
     void setBaudRate(uint32_t baud);
@@ -257,6 +258,9 @@ class STM32_CAN {
 
     PinName rx;
     PinName tx;
+
+    uint32_t preemptPriority;
+    uint32_t subPriority;
 
     CAN_HandleTypeDef *n_pCanHandle;
     CAN_TypeDef*      _canPort;

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -306,7 +306,7 @@ class STM32_CAN {
      * These return true on success
      */
     /** set filter state and action, keeps filter rules intact */
-    bool setFilter(uint8_t bank_num, bool state, FilterAction action = CAN_FILTER_DEFAULT_ACTION);
+    bool setFilter(uint8_t bank_num, bool enabled, FilterAction action = CAN_FILTER_DEFAULT_ACTION);
     bool setFilterSingleMask(uint8_t bank_num, uint32_t id, uint32_t mask, IDE std_ext, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
     bool setFilterDualID(uint8_t bank_num, uint32_t id1, uint32_t id2, IDE std_ext1, IDE std_ext2, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
     bool setFilterDualMask(uint8_t bank_num, uint32_t id1, uint32_t mask1, IDE std_ext1, uint32_t id2, uint32_t mask2, IDE std_ext2, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -369,6 +369,7 @@ class STM32_CAN {
 
     Mode mode;
     uint32_t baudrate;
+    bool filtersInitialized;
 
     PinName rx;
     PinName tx;

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -262,11 +262,15 @@ class STM32_CAN {
     bool write(CAN_message_t &CAN_tx_msg, bool sendMB = false);
     bool read(CAN_message_t &CAN_rx_msg);
     // Manually set STM32 filter bank parameters
-    bool setFilterSingleMask(uint8_t bank_num, uint32_t id, uint32_t mask, IDE std_ext, uint32_t fifo = CAN_FILTER_FIFO0, bool enabled = true);
-    bool setFilterDualID(uint8_t bank_num, uint32_t id1, uint32_t id2, IDE std_ext1, IDE std_ext2, uint32_t fifo = CAN_FILTER_FIFO0, bool enabled = true);
-    bool setFilterDualMask(uint8_t bank_num, uint32_t id1, uint32_t mask1, IDE std_ext1, uint32_t id2, uint32_t mask2, IDE std_ext2, uint32_t fifo = CAN_FILTER_FIFO0, bool enabled = true);
-    bool setFilterQuadID(uint8_t bank_num, uint32_t id1, IDE std_ext1, uint32_t id2, IDE std_ext2, uint32_t id3, IDE std_ext3, uint32_t id4, IDE std_ext4, uint32_t fifo = CAN_FILTER_FIFO0, bool enabled = true);
-    bool setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint32_t filter_mode, uint32_t filter_scale, uint32_t fifo = CAN_FILTER_FIFO0, bool enabled = true);
+    enum FilterAction {
+      STORE_FIFO0,
+      STORE_FIFO1
+    };
+    bool setFilterSingleMask(uint8_t bank_num, uint32_t id, uint32_t mask, IDE std_ext, FilterAction action = STORE_FIFO0, bool enabled = true);
+    bool setFilterDualID(uint8_t bank_num, uint32_t id1, uint32_t id2, IDE std_ext1, IDE std_ext2, FilterAction action = STORE_FIFO0, bool enabled = true);
+    bool setFilterDualMask(uint8_t bank_num, uint32_t id1, uint32_t mask1, IDE std_ext1, uint32_t id2, uint32_t mask2, IDE std_ext2, FilterAction action = STORE_FIFO0, bool enabled = true);
+    bool setFilterQuadID(uint8_t bank_num, uint32_t id1, IDE std_ext1, uint32_t id2, IDE std_ext2, uint32_t id3, IDE std_ext3, uint32_t id4, IDE std_ext4, FilterAction action = STORE_FIFO0, bool enabled = true);
+    bool setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint32_t filter_mode, uint32_t filter_scale, FilterAction action = STORE_FIFO0, bool enabled = true);
     // Legacy, broken! Only works correctly for 32 bit mask mode
     bool setFilter(uint8_t bank_num, uint32_t filter_id, uint32_t mask, IDE = AUTO, uint32_t filter_mode = CAN_FILTERMODE_IDMASK, uint32_t filter_scale = CAN_FILTERSCALE_32BIT, uint32_t fifo = CAN_FILTER_FIFO0);
     // Teensy FlexCAN style "set filter" -functions

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -32,6 +32,14 @@ to same folder with sketch and haven #define HAL_CAN_MODULE_ENABLED there. See e
    */
   #define CAN1_IRQn_AIO       CEC_CAN_IRQn
   #define CAN1_IRQHandler_AIO CEC_CAN_IRQHandler
+  /**
+   * NOTE: CAN IRQ is shared with CEC
+   * To use CEC with CAN declare:
+   * CEC_HandleTypeDef * phcec;
+   * and point to your CEC handle.
+   * Internal IRQ Handler will call CEC Handler as well.
+   */
+  #define STM32_CAN1_SHARED_WITH_CEC
 
 #endif
 #endif

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -321,7 +321,7 @@ class STM32_CAN {
 
     template <typename T, size_t N>
     bool      lookupBaudrate(CAN_HandleTypeDef *CanHandle, int Baudrate, const T(&table)[N]);
-    void      calculateBaudrate(CAN_HandleTypeDef *CanHandle, int Baudrate);
+    bool      calculateBaudrate(CAN_HandleTypeDef *CanHandle, int Baudrate);
     void      setBaudRateValues(CAN_HandleTypeDef *CanHandle, uint16_t prescaler, uint8_t timeseg1,
                                                               uint8_t timeseg2, uint8_t sjw);
     uint32_t  getAPB1Clock(void);

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -253,14 +253,14 @@ typedef struct {
 class STM32_CAN {
 
   public:
-    enum Mode {
+    enum MODE {
       NORMAL               = CAN_MODE_NORMAL,
       SILENT               = CAN_MODE_SILENT,
       SILENT_LOOPBACK      = CAN_MODE_SILENT_LOOPBACK,
       LOOPBACK             = CAN_MODE_LOOPBACK
     };
 
-    enum FilterAction {
+    enum FILTER_ACTION {
       STORE_FIFO0,
       STORE_FIFO1,
     };
@@ -278,7 +278,7 @@ class STM32_CAN {
  */
     void setIRQPriority(uint32_t preemptPriority, uint32_t subPriority);
 
-    void setMode(Mode mode);
+    void setMode(MODE mode);
     void enableLoopBack(bool yes = 1);
     void enableSilentMode(bool yes = 1);
     void enableSilentLoopBack(bool yes = 1);
@@ -313,12 +313,12 @@ class STM32_CAN {
      * These return true on success
      */
     /** set filter state and action, keeps filter rules intact */
-    bool setFilter(uint8_t bank_num, bool enabled, FilterAction action = CAN_FILTER_DEFAULT_ACTION);
-    bool setFilterSingleMask(uint8_t bank_num, uint32_t id, uint32_t mask, IDE std_ext, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
-    bool setFilterDualID(uint8_t bank_num, uint32_t id1, uint32_t id2, IDE std_ext1, IDE std_ext2, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
-    bool setFilterDualMask(uint8_t bank_num, uint32_t id1, uint32_t mask1, IDE std_ext1, uint32_t id2, uint32_t mask2, IDE std_ext2, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
-    bool setFilterQuadID(uint8_t bank_num, uint32_t id1, IDE std_ext1, uint32_t id2, IDE std_ext2, uint32_t id3, IDE std_ext3, uint32_t id4, IDE std_ext4, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
-    bool setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint32_t filter_mode, uint32_t filter_scale, FilterAction action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
+    bool setFilter(uint8_t bank_num, bool enabled, FILTER_ACTION action = CAN_FILTER_DEFAULT_ACTION);
+    bool setFilterSingleMask(uint8_t bank_num, uint32_t id, uint32_t mask, IDE std_ext, FILTER_ACTION action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
+    bool setFilterDualID(uint8_t bank_num, uint32_t id1, uint32_t id2, IDE std_ext1, IDE std_ext2, FILTER_ACTION action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
+    bool setFilterDualMask(uint8_t bank_num, uint32_t id1, uint32_t mask1, IDE std_ext1, uint32_t id2, uint32_t mask2, IDE std_ext2, FILTER_ACTION action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
+    bool setFilterQuadID(uint8_t bank_num, uint32_t id1, IDE std_ext1, uint32_t id2, IDE std_ext2, uint32_t id3, IDE std_ext3, uint32_t id4, IDE std_ext4, FILTER_ACTION action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
+    bool setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint32_t filter_mode, uint32_t filter_scale, FILTER_ACTION action = CAN_FILTER_DEFAULT_ACTION, bool enabled = true);
     /** Legacy, broken! Only works correctly for 32 bit mask mode 
      * Retruns true on Error, false on Success (like Teensy functions, opposite of STM32 function)
     */

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -370,7 +370,6 @@ class STM32_CAN {
 
     bool     _canIsActive = false;
 
-    Mode mode;
     uint32_t baudrate;
     bool filtersInitialized;
 

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -301,6 +301,13 @@ class STM32_CAN {
     bool write(CAN_message_t &CAN_tx_msg, bool sendMB = false);
     bool read(CAN_message_t &CAN_rx_msg);
 
+    /** returns number of available filter banks. If hasSharedFilterBanks() is false counts may differ by id type. */
+    uint8_t getFilterBankCount(IDE std_ext = STD);
+    /** returns if filter count and index are shared (true) or dedicated per id type (false) */
+    bool hasSharedFilterBanks() {
+      return true;
+    }
+
     /** 
      * Manually set STM32 filter bank parameters
      * These return true on success

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -341,7 +341,7 @@ class STM32_CAN {
     bool      calculateBaudrate(CAN_HandleTypeDef *CanHandle, int Baudrate);
     void      setBaudRateValues(CAN_HandleTypeDef *CanHandle, uint16_t prescaler, uint8_t timeseg1,
                                                               uint8_t timeseg2, uint8_t sjw);
-    uint32_t  getAPB1Clock(void);
+    uint32_t  getCanPeripheralClock(void);
 
     volatile CAN_message_t *rx_buffer = nullptr;
     volatile CAN_message_t *tx_buffer = nullptr;

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -257,6 +257,7 @@ class STM32_CAN {
     void setIRQPriority(uint32_t preemptPriority, uint32_t subPriority);
     // Begin. By default the automatic retransmission is enabled. If it causes problems, use begin(false) to disable it.
     void begin(bool retransmission = false);
+    void end(void);
     void setBaudRate(uint32_t baud);
     bool write(CAN_message_t &CAN_tx_msg, bool sendMB = false);
     bool read(CAN_message_t &CAN_rx_msg);
@@ -306,6 +307,7 @@ class STM32_CAN {
     void      init(void);
     CAN_TypeDef * getPeripheral(void);
     bool      allocatePeripheral(void);
+    bool      freePeripheral(void);
     bool      hasPeripheral(void);
     void      start(void);
     void      stop(void);
@@ -313,6 +315,7 @@ class STM32_CAN {
     bool      isInitialized() { return rx_buffer != 0; }
     void      initRingBuffer(RingbufferTypeDef &ring, volatile CAN_message_t *buffer, uint32_t size);
     void      initializeBuffers(void);
+    void      freeBuffers(void);
     bool      isRingBufferEmpty(RingbufferTypeDef &ring);
     uint32_t  ringBufferCount(RingbufferTypeDef &ring);
 

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -19,20 +19,96 @@ to same folder with sketch and haven #define HAL_CAN_MODULE_ENABLED there. See e
 #ifndef STM32_CAN_H
 #define STM32_CAN_H
 
-// couple of workarounds
-#if defined(STM32F3xx)
-  #define GPIO_AF9_CAN1 GPIO_AF9_CAN
-  #define CAN1_RX0_IRQn CAN_RX0_IRQn
-  #define CAN1_TX_IRQn CAN_TX_IRQn
-  #define GPIO_SPEED_FREQ_VERY_HIGH GPIO_SPEED_FREQ_HIGH
-  #define CAN1_TX_IRQHandler CAN_TX_IRQHandler
-  #define CAN1_RX0_IRQHandler CAN_RX0_IRQHandler
+/** Handling special cases for IRQ Handlers */
+#if defined(STM32F0xx)
+#if defined(STM32F042x6) || defined(STM32F072xB) || defined(STM32F091xC) || defined(STM32F098xx)
+
+  /**
+   * NOTE: STM32F0 share IRQ Handler with HDMI CEC
+   * and there is only a single IRQ Handler not 4
+   * CEC_CAN_IRQn | CEC_CAN_IRQHandler
+   * 
+   * define all in one alias for IRQn and Handler
+   */
+  #define CAN1_IRQn_AIO       CEC_CAN_IRQn
+  #define CAN1_IRQHandler_AIO CEC_CAN_IRQHandler
+
+#endif
 #endif
 
-#if defined(STM32F0xx)
-  #define CAN1_TX_IRQn CEC_CAN_IRQn
-  #define CAN1_RX0_IRQn CEC_CAN_IRQn
-  #define CAN1_RX0_IRQHandler CEC_CAN_IRQHandler
+#if defined(STM32F1xx)
+#if defined(STM32F103x6) || defined(STM32F103xB) || defined(STM32F103xE) || defined(STM32F103xG)
+/**
+ * NOTE: STM32F103xx uses shared IRQ Handler with USB
+ * USB_HP_CAN1_TX_IRQn  | USB_HP_CAN1_TX_IRQHandler
+ * USB_LP_CAN1_RX0_IRQn | USB_LP_CAN1_RX0_IRQHandler
+ * 
+ * the CMSIS files define already aliases for the CAN *_IRQHandler and *_IRQn
+ * conforming with standard naming convention:
+ * CAN1_TX_IRQn  | CAN1_TX_IRQHandler
+ * CAN1_RX0_IRQn | CAN1_RX0_IRQHandler
+ * 
+ * when USB is enabled the USBDevice driver also implements these making a concurrent use impossible.
+ * 
+ * Following are unaffected:
+ * CAN1_RX1_IRQn | CAN1_RX1_IRQHandler
+ * CAN1_SCE_IRQn | CAN1_SCE_IRQHandler
+ */
+#endif
+#endif
+
+#if defined(STM32F3xx)
+#if defined(STM32F302x8) || defined(STM32F302xC) || defined(STM32F302xE)\
+ || defined(STM32F303xC) || defined(STM32F303xE)
+
+  /**
+   * NOTE: STM32F3 with USB share IRQ Handler with it
+   * USB_HP_CAN_TX_IRQn  | USB_HP_CAN_TX_IRQHandler
+   * USB_LP_CAN_RX0_IRQn | USB_LP_CAN_RX0_IRQHandler
+   * 
+   * the CMSIS files define already aliases for the CAN *_IRQHandler and *_IRQn
+   * missing peripheral index:
+   * CAN_TX_IRQn  | CAN_TX_IRQHandler
+   * CAN_RX0_IRQn | CAN_RX0_IRQHandler
+   * 
+   * when USB is enabled the USBDevice driver also implements these making a concurrent use impossible.
+   * 
+   * Following are unaffected:
+   * CAN_RX1_IRQn | CAN_RX1_IRQHandler
+   * CAN_SCE_IRQn | CAN_SCE_IRQHandler
+   * 
+   * define more aliases with peripheral index
+   */
+
+  #define CAN1_TX_IRQn      USB_HP_CAN_TX_IRQn
+  #define CAN1_RX0_IRQn     USB_LP_CAN_RX0_IRQn
+  #define CAN1_RX1_IRQn     CAN_RX1_IRQn
+  #define CAN1_SCE_IRQn     CAN_SCE_IRQn
+
+  #define CAN1_TX_IRQHandler  USB_HP_CAN_TX_IRQHandler
+  #define CAN1_RX0_IRQHandler USB_LP_CAN_RX0_IRQHandler
+  #define CAN1_RX1_IRQHandler CAN_RX1_IRQHandler
+  #define CAN1_SCE_IRQHandler CAN_SCE_IRQHandler
+
+#elif defined(STM32F303x8) || defined(STM32F328xx) || defined(STM32F334x8)\
+ || defined(STM32F358xx) || defined(STM32F373xC)\
+ || defined(STM32F378xx) || defined(STM32F398xx)
+
+  /**
+   * NOTE: STM32F3 without USB define symbols without peripheral index
+   * define more aliases with peripheral index
+   */
+
+  #define CAN1_TX_IRQn      CAN_TX_IRQn
+  #define CAN1_RX0_IRQn     CAN_RX0_IRQn
+  #define CAN1_RX1_IRQn     CAN_RX1_IRQn
+  #define CAN1_SCE_IRQn     CAN_SCE_IRQn
+  
+  #define CAN1_TX_IRQHandler  CAN_TX_IRQHandler
+  #define CAN1_RX0_IRQHandler CAN_RX0_IRQHandler
+  #define CAN1_RX1_IRQHandler CAN_RX1_IRQHandler
+  #define CAN1_SCE_IRQHandler CAN_SCE_IRQHandler
+#endif
 #endif
 
 #include <Arduino.h>

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -366,6 +366,7 @@ class STM32_CAN {
     bool     _canIsActive = false;
 
     Mode mode;
+    uint32_t baudrate;
 
     PinName rx;
     PinName tx;

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -160,6 +160,14 @@ class STM32_CAN {
     bool setMBFilter(CAN_BANK bank_num, uint32_t id1, IDE = AUTO); /* input 1 ID to be filtered */
     bool setMBFilter(CAN_BANK bank_num, uint32_t id1, uint32_t id2, IDE = AUTO); /* input 2 ID's to be filtered */
 
+    enum Mode {
+      NORMAL               = CAN_MODE_NORMAL,
+      LOOPBACK             = CAN_MODE_LOOPBACK,
+      SILENT               = CAN_MODE_SILENT,
+      SILENT_LOOPBACK      = CAN_MODE_SILENT_LOOPBACK
+    };
+
+    void setMode(Mode mode);
     void enableLoopBack(bool yes = 1);
     void enableSilentMode(bool yes = 1);
     void enableSilentLoopBack(bool yes = 1);
@@ -244,6 +252,8 @@ class STM32_CAN {
     };
 
     bool     _canIsActive = false;
+
+    Mode mode;
 
     PinName rx;
     PinName tx;

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -279,6 +279,7 @@ class STM32_CAN {
     STM32_CAN(CAN_TypeDef* canPort, RXQUEUE_TABLE rxSize = RX_SIZE_16, TXQUEUE_TABLE txSize = TX_SIZE_16);
     //legacy for compatibility
     STM32_CAN(CAN_TypeDef* canPort, CAN_PINS pins, RXQUEUE_TABLE rxSize = RX_SIZE_16, TXQUEUE_TABLE txSize = TX_SIZE_16);
+    ~STM32_CAN();
 /**-------------------------------------------------------------
  *     setup functions
  *     no effect after begin()

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -105,7 +105,9 @@ to same folder with sketch and haven #define HAL_CAN_MODULE_ENABLED there. See e
   #define CAN1_RX1_IRQHandler CAN_RX1_IRQHandler
   #define CAN1_SCE_IRQHandler CAN_SCE_IRQHandler
 
-  #ifdef USBCON
+  /** NOTE: USE_USB_INTERRUPT_REMAPPED may be used to use 
+   * different USB IRQs and not block the CAN IRQ handlers */
+  #if defined(USBCON) && !defined(USE_USB_INTERRUPT_REMAPPED)
   #define STM32_CAN1_TX_RX0_BLOCKED_BY_USB
   #endif
 

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -122,7 +122,7 @@ to same folder with sketch and haven #define HAL_CAN_MODULE_ENABLED there. See e
   #define CAN1_RX0_IRQn     CAN_RX0_IRQn
   #define CAN1_RX1_IRQn     CAN_RX1_IRQn
   #define CAN1_SCE_IRQn     CAN_SCE_IRQn
-  
+
   #define CAN1_TX_IRQHandler  CAN_TX_IRQHandler
   #define CAN1_RX0_IRQHandler CAN_RX0_IRQHandler
   #define CAN1_RX1_IRQHandler CAN_RX1_IRQHandler
@@ -307,6 +307,8 @@ class STM32_CAN {
     CAN_TypeDef * getPeripheral(void);
     bool      allocatePeripheral(void);
     bool      hasPeripheral(void);
+    void      start(void);
+    void      stop(void);
     void      initializeFilters();
     bool      isInitialized() { return rx_buffer != 0; }
     void      initRingBuffer(RingbufferTypeDef &ring, volatile CAN_message_t *buffer, uint32_t size);

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -262,6 +262,12 @@ class STM32_CAN {
     bool write(CAN_message_t &CAN_tx_msg, bool sendMB = false);
     bool read(CAN_message_t &CAN_rx_msg);
     // Manually set STM32 filter bank parameters
+    bool setFilterSingleMask(uint8_t bank_num, uint32_t id, uint32_t mask, IDE std_ext, uint32_t fifo = CAN_FILTER_FIFO0, bool enabled = true);
+    bool setFilterDualID(uint8_t bank_num, uint32_t id1, uint32_t id2, IDE std_ext1, IDE std_ext2, uint32_t fifo = CAN_FILTER_FIFO0, bool enabled = true);
+    bool setFilterDualMask(uint8_t bank_num, uint32_t id1, uint32_t mask1, IDE std_ext1, uint32_t id2, uint32_t mask2, IDE std_ext2, uint32_t fifo = CAN_FILTER_FIFO0, bool enabled = true);
+    bool setFilterQuadID(uint8_t bank_num, uint32_t id1, IDE std_ext1, uint32_t id2, IDE std_ext2, uint32_t id3, IDE std_ext3, uint32_t id4, IDE std_ext4, uint32_t fifo = CAN_FILTER_FIFO0, bool enabled = true);
+    bool setFilterRaw(uint8_t bank_num, uint32_t id, uint32_t mask, uint32_t filter_mode, uint32_t filter_scale, uint32_t fifo = CAN_FILTER_FIFO0, bool enabled = true);
+    // Legacy, broken! Only works correctly for 32 bit mask mode
     bool setFilter(uint8_t bank_num, uint32_t filter_id, uint32_t mask, IDE = AUTO, uint32_t filter_mode = CAN_FILTERMODE_IDMASK, uint32_t filter_scale = CAN_FILTERSCALE_32BIT, uint32_t fifo = CAN_FILTER_FIFO0);
     // Teensy FlexCAN style "set filter" -functions
     bool setMBFilterProcessing(CAN_BANK bank_num, uint32_t filter_id, uint32_t mask, IDE = AUTO);


### PR DESCRIPTION
I implemented FDCAN support for this library (see FDCAN branch in my fork). During this I implemented a few new features.

This PR only includes the changes that apply to the current CAN peripheral (bxCAN). The FDCAN implementation essentially uses this as a base.

This PR includes quite a lot of changes:

- Define CAN interface by Tx and Rx pins
  - allows all possible combinations of Tx/Rx pins
  - checks if alternate functions are correctly grouped on the F1 platform (special case)
  - old style still supported
- setters for additional options
  - IRQ Priority, AutoBusOff, AutoRetransmission, ...
- expanded filter api
  - current filter function is bugged. Added fixed version and extra functions for ease of use
- allow setBaudRate to be called before or after begin()
  - also while running to switch baudrate
- complete lifecycle functions
  - added end() to tear down CAN and free resources
- changed how instances reserve CAN instances
  - class objects contain peripheral handler, no risk of writing into non valid memory
  - register in global to claim peripheral once peripheral will be started
  - IRQ can retrieve STM32_CAN instances from global by "container_of" magic
  - inspired by Arduino core Hardware Timer implementation
- IRQ mapping of all platforms
  - added special handling for F0 for shared CEC IRQ
  - workaround for F1 and F3 for shared IRQ with USB

The current API should be untouched. Old projects should work as before. I tried to only expand the API.

Tested on Nucleo-F303K8, Nucleo-F767ZI. Loopback only, no CAN Transceiver.

This fixes the following issues:
- #1
- #35
- #36
- #37