### PR TITLE
Fix f1 platform

### DIFF
--- a/STM32_CAN.cpp
+++ b/STM32_CAN.cpp
@@ -353,7 +353,9 @@ void STM32_CAN::begin( bool retransmission ) {
    * This lets loopback only tests without external circuitry sill function.
    */
   uint32_t rx_func = pinmap_function(rx, PinMap_CAN_RD);
-  pin_function(rx, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_PULLUP, STM_PIN_AFNUM(rx_func)));
+  rx_func = (rx_func & ~(STM_PIN_PUPD_MASK << STM_PIN_PUPD_SHIFT)) 
+          | (GPIO_PULLUP << STM_PIN_PUPD_SHIFT);
+  pin_function(rx, rx_func);
   if(tx != NC)
   {
     pin_function(tx, pinmap_function(tx, PinMap_CAN_TD));

--- a/STM32_CAN.h
+++ b/STM32_CAN.h
@@ -400,6 +400,7 @@ class STM32_CAN {
     void      setBaudRateValues(uint16_t prescaler, uint8_t timeseg1,
                                 uint8_t timeseg2, uint8_t sjw);
     uint32_t  getCanPeripheralClock(void);
+    uint32_t  fixPinFunction(uint32_t function);
 
     volatile CAN_message_t *rx_buffer = nullptr;
     volatile CAN_message_t *tx_buffer = nullptr;

--- a/examples/Read-Write_with_filters/hal_conf_extra.h
+++ b/examples/Read-Write_with_filters/hal_conf_extra.h
@@ -1,6 +1,11 @@
 #if !defined(HAL_CAN_MODULE_ENABLED)
     #define HAL_CAN_MODULE_ENABLED
 
+    #if defined(STM32F1xx)
+        /** NOTE: Enable special alternate function remapping for F1 platform*/
+        #define AFIO_MAPR_CAN_REMAP1
+    #endif
+
     #if defined(USBCON) && defined(STM32F1xx)
         /** NOTE: On the F1 platform CAN and USB may not be used at the same time.
          * To still allow a program to be build that may use both

--- a/examples/Read-Write_with_filters/hal_conf_extra.h
+++ b/examples/Read-Write_with_filters/hal_conf_extra.h
@@ -1,3 +1,28 @@
 #if !defined(HAL_CAN_MODULE_ENABLED)
-#define HAL_CAN_MODULE_ENABLED
+    #define HAL_CAN_MODULE_ENABLED
+
+    #if defined(USBCON) && defined(STM32F1xx)
+        /** NOTE: On the F1 platform CAN and USB may not be used at the same time.
+         * To still allow a program to be build that may use both
+         * but not at the same time this workaround may be enabled.
+         * Since USB driver is using the shared IRQ handlers, the CAN driver has no access to them.
+         * To handle Tx events call
+         * 
+         * STM32_CAN_Poll_IRQ_Handler()
+         * 
+         * frequently
+         */
+        // #define STM32_CAN_USB_WORKAROUND_POLLING
+    #endif
+
+    #if defined(USBCON) && defined(STM32F3xx)
+        /** NOTE: On F3 platform CAN and USB share IRQ by default.
+         *  Since USB driver is using the shared IRQ handlers, the CAN driver has no access to them.
+         * 
+         *  Below define maps the USB IRQs to alternate IRQ vectors, 
+         *  so USB and CAN IRQs are no longer shared
+         */
+        // #define USE_USB_INTERRUPT_REMAPPED
+    #endif
+
 #endif

--- a/examples/Read/hal_conf_extra.h
+++ b/examples/Read/hal_conf_extra.h
@@ -1,6 +1,11 @@
 #if !defined(HAL_CAN_MODULE_ENABLED)
     #define HAL_CAN_MODULE_ENABLED
 
+    #if defined(STM32F1xx)
+        /** NOTE: Enable special alternate function remapping for F1 platform*/
+        #define AFIO_MAPR_CAN_REMAP1
+    #endif
+
     #if defined(USBCON) && defined(STM32F1xx)
         /** NOTE: On the F1 platform CAN and USB may not be used at the same time.
          * To still allow a program to be build that may use both

--- a/examples/Read/hal_conf_extra.h
+++ b/examples/Read/hal_conf_extra.h
@@ -1,3 +1,28 @@
 #if !defined(HAL_CAN_MODULE_ENABLED)
-#define HAL_CAN_MODULE_ENABLED
+    #define HAL_CAN_MODULE_ENABLED
+
+    #if defined(USBCON) && defined(STM32F1xx)
+        /** NOTE: On the F1 platform CAN and USB may not be used at the same time.
+         * To still allow a program to be build that may use both
+         * but not at the same time this workaround may be enabled.
+         * Since USB driver is using the shared IRQ handlers, the CAN driver has no access to them.
+         * To handle Tx events call
+         * 
+         * STM32_CAN_Poll_IRQ_Handler()
+         * 
+         * frequently
+         */
+        // #define STM32_CAN_USB_WORKAROUND_POLLING
+    #endif
+
+    #if defined(USBCON) && defined(STM32F3xx)
+        /** NOTE: On F3 platform CAN and USB share IRQ by default.
+         *  Since USB driver is using the shared IRQ handlers, the CAN driver has no access to them.
+         * 
+         *  Below define maps the USB IRQs to alternate IRQ vectors, 
+         *  so USB and CAN IRQs are no longer shared
+         */
+        // #define USE_USB_INTERRUPT_REMAPPED
+    #endif
+
 #endif

--- a/examples/Sniffer/hal_conf_extra.h
+++ b/examples/Sniffer/hal_conf_extra.h
@@ -1,6 +1,11 @@
 #if !defined(HAL_CAN_MODULE_ENABLED)
     #define HAL_CAN_MODULE_ENABLED
 
+    #if defined(STM32F1xx)
+        /** NOTE: Enable special alternate function remapping for F1 platform*/
+        #define AFIO_MAPR_CAN_REMAP1
+    #endif
+
     #if defined(USBCON) && defined(STM32F1xx)
         /** NOTE: On the F1 platform CAN and USB may not be used at the same time.
          * To still allow a program to be build that may use both

--- a/examples/Sniffer/hal_conf_extra.h
+++ b/examples/Sniffer/hal_conf_extra.h
@@ -1,3 +1,28 @@
 #if !defined(HAL_CAN_MODULE_ENABLED)
-#define HAL_CAN_MODULE_ENABLED
+    #define HAL_CAN_MODULE_ENABLED
+
+    #if defined(USBCON) && defined(STM32F1xx)
+        /** NOTE: On the F1 platform CAN and USB may not be used at the same time.
+         * To still allow a program to be build that may use both
+         * but not at the same time this workaround may be enabled.
+         * Since USB driver is using the shared IRQ handlers, the CAN driver has no access to them.
+         * To handle Tx events call
+         * 
+         * STM32_CAN_Poll_IRQ_Handler()
+         * 
+         * frequently
+         */
+        // #define STM32_CAN_USB_WORKAROUND_POLLING
+    #endif
+
+    #if defined(USBCON) && defined(STM32F3xx)
+        /** NOTE: On F3 platform CAN and USB share IRQ by default.
+         *  Since USB driver is using the shared IRQ handlers, the CAN driver has no access to them.
+         * 
+         *  Below define maps the USB IRQs to alternate IRQ vectors, 
+         *  so USB and CAN IRQs are no longer shared
+         */
+        // #define USE_USB_INTERRUPT_REMAPPED
+    #endif
+
 #endif

--- a/examples/Write/hal_conf_extra.h
+++ b/examples/Write/hal_conf_extra.h
@@ -1,6 +1,11 @@
 #if !defined(HAL_CAN_MODULE_ENABLED)
     #define HAL_CAN_MODULE_ENABLED
 
+    #if defined(STM32F1xx)
+        /** NOTE: Enable special alternate function remapping for F1 platform*/
+        #define AFIO_MAPR_CAN_REMAP1
+    #endif
+
     #if defined(USBCON) && defined(STM32F1xx)
         /** NOTE: On the F1 platform CAN and USB may not be used at the same time.
          * To still allow a program to be build that may use both

--- a/examples/Write/hal_conf_extra.h
+++ b/examples/Write/hal_conf_extra.h
@@ -1,3 +1,28 @@
 #if !defined(HAL_CAN_MODULE_ENABLED)
-#define HAL_CAN_MODULE_ENABLED
+    #define HAL_CAN_MODULE_ENABLED
+
+    #if defined(USBCON) && defined(STM32F1xx)
+        /** NOTE: On the F1 platform CAN and USB may not be used at the same time.
+         * To still allow a program to be build that may use both
+         * but not at the same time this workaround may be enabled.
+         * Since USB driver is using the shared IRQ handlers, the CAN driver has no access to them.
+         * To handle Tx events call
+         * 
+         * STM32_CAN_Poll_IRQ_Handler()
+         * 
+         * frequently
+         */
+        // #define STM32_CAN_USB_WORKAROUND_POLLING
+    #endif
+
+    #if defined(USBCON) && defined(STM32F3xx)
+        /** NOTE: On F3 platform CAN and USB share IRQ by default.
+         *  Since USB driver is using the shared IRQ handlers, the CAN driver has no access to them.
+         * 
+         *  Below define maps the USB IRQs to alternate IRQ vectors, 
+         *  so USB and CAN IRQs are no longer shared
+         */
+        // #define USE_USB_INTERRUPT_REMAPPED
+    #endif
+
 #endif


### PR DESCRIPTION
This PR contains 3 fixes regarding the F1 platform.
Additionally the `hal_conf_extra.h` files of the examples got a few extra notes about optional configuration defines.

### Alternate pinmap broken
With recent changes the handling of alternate function settings was was changed, letting the Arduino core do the low level work.
This caused a bug where the F1 platform alternate function re-mapping did not work.
A missing define prevented the actual remapping being called.
```c
[...]
#if defined(AFIO_MAPR_CAN_REMAP1)
    case AFIO_CAN1_1:
      __HAL_AFIO_REMAP_CAN1_1();
      break;
    case AFIO_CAN1_2:
      __HAL_AFIO_REMAP_CAN1_2();
      break;
    case AFIO_CAN1_3:
      __HAL_AFIO_REMAP_CAN1_3();
      break;
#endif
[...]
```
The necessary define is now defined in `hal_conf_extra.h` by default.
Possible fix for #47, #51, #52, parts of #49


### RX pinmode clobbered
The CAN driver does enable the Pullup on the RX pin. The implementation did assume all defined pinmodes by Arduino use the `STM_MODE_AF_PP` for the CAN pins. This is not the case for the F1 platform, it uses `STM_MODE_INPUT` for.

This PR contains a fix that no longer touches the mode, instead just modifies the pullup section of the pin function.


### Alternate pinmode not defined
F103 platform files don't define a valid AFIO mode for the default pinmap.
```c
WEAK const PinMap PinMap_CAN_TD[] = {
  {PA_12, CAN1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, AFIO_NONE)},
  {PB_9,  CAN1, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, AFIO_CAN1_2)},
  {NC,    NP,   0}
};
```
Instead of defining `AFIO_CAN1_1` just `AFIO_NONE` is used. This is no problem if the default is used since it is already active, or changing to another mode since it is defined. But when returning to the default mode after using an alternate mode previously (without reset), the correct mode would not be set, since none is defined (rare case).

This PR contains a workaround that checks for `AFIO_NONE` and overwrites it with the expected `AFIO_CAN1_1` to correctly re-set the AFIO mode.

